### PR TITLE
chore: enable docker-only production deployment

### DIFF
--- a/deploy/docker/Caddyfile
+++ b/deploy/docker/Caddyfile
@@ -1,5 +1,32 @@
 {
   auto_https disable_redirects
+  email {$CADDY_ADMIN_EMAIL}
+}
+
+https://{$PAYPAY_DOMAIN} {
+  encode gzip
+
+  @api path /api/*
+  handle @api {
+    reverse_proxy bff:4000
+  }
+
+  handle_path /healthz {
+    reverse_proxy bff:4000
+  }
+
+  handle_path /readyz {
+    reverse_proxy bff:4000
+  }
+
+  handle {
+    reverse_proxy frontend:3000
+  }
+}
+
+https://{$PAYPAY_API_DOMAIN} {
+  encode gzip
+  reverse_proxy bff:4000
 }
 
 https://localhost {

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     image: ghcr.io/paypay/frontend:latest
     restart: unless-stopped
     env_file:
-      - ../../infra/env/.env.frontend
+      - ../../infra/env/.env
     environment:
       NODE_ENV: production
     depends_on:
@@ -34,7 +34,7 @@ services:
     image: ghcr.io/paypay/bff:latest
     restart: unless-stopped
     env_file:
-      - ../../infra/env/.env.bff
+      - ../../infra/env/.env
     environment:
       NODE_ENV: production
     depends_on:
@@ -94,6 +94,8 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy-data:/data
       - caddy-config:/config
+    env_file:
+      - ../../infra/env/.env
     depends_on:
       - frontend
       - bff

--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -1,0 +1,40 @@
+# Global deployment configuration for the PayPay stack.
+# Copy this file to infra/env/.env and fill in the secrets before running docker compose.
+
+# --- Public domains & TLS ---
+# Primary UI domain served by Caddy and Next.js (e.g. paypay.example.com)
+PAYPAY_DOMAIN=
+# Public API domain for the NestJS BFF (e.g. api.paypay.example.com)
+PAYPAY_API_DOMAIN=
+# Email used by Caddy when requesting certificates from Let's Encrypt/ZeroSSL
+CADDY_ADMIN_EMAIL=
+
+# --- Frontend (Next.js) ---
+# Public origin of the BFF; must be https://<PAYPAY_API_DOMAIN>
+NEXT_PUBLIC_BFF_URL=
+# Base path used by the frontend when calling the BFF (typically https://<PAYPAY_API_DOMAIN>/api)
+NEXT_PUBLIC_API_BASE=
+
+# --- BFF (NestJS) ---
+# Browser origin allowed by CORS; must be https://<PAYPAY_DOMAIN>
+FRONTEND_ORIGIN=
+# URL of the BTCPay Server instance (legacy name kept for compatibility)
+BTCPAY_URL=
+# Alternative variable name for BTCPAY_URL if you prefer BASE_URL semantics
+BTCPAY_BASE_URL=
+BTCPAY_API_KEY=
+BTCPAY_WEBHOOK_SECRET=
+STORE_ID=
+BFF_URL=http://bff:4000
+JWT_ACCESS_SECRET=
+JWT_REFRESH_SECRET=
+
+# --- Data stores ---
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=paypay
+POSTGRES_USER=paypay
+POSTGRES_PASSWORD=paypay
+
+REDIS_HOST=redis
+REDIS_PORT=6379


### PR DESCRIPTION
## Summary
- template the Caddyfile with domain and admin email environment variables while proxying frontend and BFF targets
- wire Docker Compose services to a shared env file for frontend/BFF/Caddy and add a consolidated env template
- rewrite the README to document Docker-only production setup and optional local pnpm workflows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6f1c268e4832f88dc229d85c9ee47