### PR TITLE
feat(bff): apply global CSRF guard and update refresh token config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ PayPay is a monorepo housing the Next.js merchant portal, NestJS BFF, and a type
    - `PAYPAY_DOMAIN` / `PAYPAY_API_DOMAIN` – public domains that end-users will visit.
    - `CADDY_ADMIN_EMAIL` – email for ACME certificate management.
    - `NEXT_PUBLIC_BFF_URL` – must be `https://<PAYPAY_API_DOMAIN>` so the frontend CSP allows calls to the BFF.
-   - `NEXT_PUBLIC_API_BASE` – defaults to `https://${PAYPAY_API_DOMAIN}/api`; adjust if you expose the API elsewhere.
+  - `NEXT_PUBLIC_API_BASE` – defaults to `https://<PAYPAY_API_DOMAIN>/api`; adjust if you expose the API elsewhere.
    - `FRONTEND_ORIGIN` – must be `https://<PAYPAY_DOMAIN>` so the BFF CORS policy matches the UI.
    - `BTCPAY_URL` / `BTCPAY_BASE_URL`, `BTCPAY_API_KEY`, `BTCPAY_WEBHOOK_SECRET`, `STORE_ID` – credentials for your BTCPay Server tenant.
    - `JWT_ACCESS_TOKEN_SECRET` and `JWT_REFRESH_TOKEN_SECRET` – secrets for issuing user tokens.

--- a/apps/bff/src/app.module.ts
+++ b/apps/bff/src/app.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DataSourceOptions } from 'typeorm';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import { CsrfGuard } from './auth/csrf.guard';
 import { LoggerModule } from 'nestjs-pino';
 import { BtcpayModule } from './btcpay/btcpay.module';
 import { InvoicesModule } from './invoices/invoices.module';
@@ -102,6 +103,10 @@ import { RefreshTokenEntity } from './auth/entities/refresh-token.entity';
     {
       provide: APP_GUARD,
       useClass: ThrottlerGuard
+    },
+    {
+      provide: APP_GUARD,
+      useClass: CsrfGuard
     }
   ]
 })

--- a/apps/bff/src/auth/auth.controller.ts
+++ b/apps/bff/src/auth/auth.controller.ts
@@ -7,8 +7,7 @@ import {
   Post,
   Req,
   Res,
-  UnauthorizedException,
-  UseGuards
+  UnauthorizedException
 } from '@nestjs/common';
 import { SkipThrottle, Throttle } from '@nestjs/throttler';
 import type { Request, Response } from 'express';
@@ -27,7 +26,6 @@ import {
   REFRESH_TOKEN_TTL_MS
 } from './auth.constants';
 import { CsrfService } from './csrf.service';
-import { CsrfGuard } from './csrf.guard';
 
 const IS_PROD = process.env.NODE_ENV === 'production';
 
@@ -48,7 +46,6 @@ const REFRESH_COOKIE_OPTIONS = {
 };
 
 @Controller('auth')
-@UseGuards(CsrfGuard)
 export class AuthController {
   constructor(private readonly authService: AuthService, private readonly csrfService: CsrfService) {}
 

--- a/apps/bff/src/auth/auth.service.ts
+++ b/apps/bff/src/auth/auth.service.ts
@@ -143,7 +143,8 @@ export class AuthService {
         expiresIn: `${Math.floor(REFRESH_TOKEN_TTL_MS / 1000)}s`,
         jwtid: tokenId,
         issuer: ACCESS_TOKEN_ISSUER,
-        audience: ACCESS_TOKEN_AUDIENCE
+        audience: ACCESS_TOKEN_AUDIENCE,
+        algorithm: ACCESS_TOKEN_ALGORITHM
       }
     );
 

--- a/apps/bff/src/main.ts
+++ b/apps/bff/src/main.ts
@@ -27,7 +27,7 @@ async function bootstrap() {
     origin,
     credentials: true,
     methods: ['POST', 'GET'],
-    allowedHeaders: ['Content-Type', 'X-CSRF-Token'],
+    allowedHeaders: ['Content-Type', 'X-CSRF-Token', 'x-csrf-token', 'Accept'],
     optionsSuccessStatus: 204
   });
 


### PR DESCRIPTION
## Summary
- register the CsrfGuard as a global APP_GUARD and remove the redundant controller-level guard
- widen CORS allowed headers to cover CSRF token casing variants and keep refresh-token signing explicit
- clarify the README default for NEXT_PUBLIC_API_BASE

## Testing
- `pnpm --filter bff test`


------
https://chatgpt.com/codex/tasks/task_e_68d931fdafb8832f8a1d80744ddbd32a