### PR TITLE
fix: configure trust proxy and cors for bff

### DIFF
--- a/apps/bff/src/main.ts
+++ b/apps/bff/src/main.ts
@@ -8,6 +8,15 @@ import cookieParser from 'cookie-parser';
 import { Logger } from 'nestjs-pino';
 import { AppModule } from './app.module';
 
+function parseTrustProxy(v?: string): any {
+  if (!v || v === '') return true;
+  const lower = v.toLowerCase();
+  if (lower === 'false' || lower === '0') return false;
+  if (lower === 'true') return true;
+  const num = Number(v);
+  return Number.isNaN(num) ? v : num;
+}
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
   const configService = app.get(ConfigService);
@@ -16,20 +25,32 @@ async function bootstrap() {
 
   useContainer(app.select(AppModule), { fallbackOnErrors: true });
 
-  app.set('trust proxy', 1);
   app.use(helmet());
   app.use(cookieParser());
 
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true }));
 
-  const origin = configService.get<string>('FRONTEND_ORIGIN') ?? 'http://localhost:3000';
+  const frontendOrigin = configService.get<string>('FRONTEND_ORIGIN');
+  const paypayDomain = configService.get<string>('PAYPAY_DOMAIN');
+  const computedOrigin = frontendOrigin || (paypayDomain ? `https://${paypayDomain}` : undefined);
   app.enableCors({
-    origin,
+    origin: computedOrigin ? [computedOrigin] : false,
     credentials: true,
     methods: ['POST', 'GET'],
     allowedHeaders: ['Content-Type', 'X-CSRF-Token', 'x-csrf-token', 'Accept'],
     optionsSuccessStatus: 204
   });
+
+  const httpAdapter = app.getHttpAdapter();
+  const type = httpAdapter.getType();
+  const instance = httpAdapter.getInstance();
+  const trustProxyValue = parseTrustProxy(configService.get<string>('TRUST_PROXY'));
+
+  if (type === 'express' && typeof (instance as any).set === 'function') {
+    (instance as any).set('trust proxy', trustProxyValue);
+  } else if (type === 'fastify') {
+    (instance as any).trustProxy = trustProxyValue;
+  }
 
   app.setGlobalPrefix('api', {
     exclude: [
@@ -39,7 +60,7 @@ async function bootstrap() {
   });
 
   const port = configService.get<number>('PORT') ?? 4000;
-  await app.listen(port);
+  await app.listen(port, '0.0.0.0');
   logger.log(`🚀 BFF is running at http://0.0.0.0:${port}`);
 }
 

--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -29,6 +29,10 @@ BFF_URL=http://bff:4000
 JWT_ACCESS_TOKEN_SECRET=
 JWT_REFRESH_TOKEN_SECRET=
 
+# --- Proxies ---
+# Trust the first proxy (Caddy/Ingress). Can be: true|false|number|string
+TRUST_PROXY=1
+
 # --- Data stores ---
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432


### PR DESCRIPTION
## Summary
- add adapter-aware trust proxy configuration in the NestJS BFF bootstrap
- restrict BFF CORS origin to the configured frontend domain and listen on 0.0.0.0 for containers
- document TRUST_PROXY default in the shared environment example

## Testing
- pnpm -r build
- pnpm --filter bff build

------
https://chatgpt.com/codex/tasks/task_e_68d952c04e34832fb0ea538535fa2eba