### PR TITLE
Fix default trust proxy configuration

### DIFF
--- a/apps/bff/src/main.ts
+++ b/apps/bff/src/main.ts
@@ -9,12 +9,18 @@ import { Logger } from 'nestjs-pino';
 import { AppModule } from './app.module';
 
 function parseTrustProxy(v?: string): any {
-  if (!v || v === '') return true;
-  const lower = v.toLowerCase();
+  if (v === undefined) {
+    return 1;
+  }
+  const normalized = v.trim();
+  if (normalized === '') {
+    return 1;
+  }
+  const lower = normalized.toLowerCase();
   if (lower === 'false' || lower === '0') return false;
   if (lower === 'true') return true;
-  const num = Number(v);
-  return Number.isNaN(num) ? v : num;
+  const num = Number(normalized);
+  return Number.isNaN(num) ? normalized : num;
 }
 
 async function bootstrap() {


### PR DESCRIPTION
## Summary
- default the TRUST_PROXY configuration to the first upstream proxy when unset
- normalize the TRUST_PROXY value before parsing so whitespace-only inputs fall back to the default

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d956f8e264832fbf9cee80bf2a26a6