### PR TITLE
Fix BFF runtime entrypoint discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,42 @@ pnpm --filter sdk gen:api
 ```
 
 You can also spin up the Docker stack locally with the same production instructions after tailoring `infra/env/.env` to your machine.
+
+## Secrets and Required Variables
+
+### JWT secrets
+- Used to sign access and refresh tokens.
+- Generate them with:
+  ```bash
+  openssl rand -hex 64  # JWT_ACCESS_TOKEN_SECRET
+  openssl rand -hex 64  # JWT_REFRESH_TOKEN_SECRET
+  ```
+
+### BTCPay webhook secret
+- Validates webhook authenticity from BTCPay Server.
+- Generate it with:
+  ```bash
+  openssl rand -hex 32
+  ```
+- When creating a webhook in BTCPay, set this value in the **Secret** field.
+
+### Mandatory environment variables
+- `FRONTEND_ORIGIN=https://paypay.iddqd.in`
+- `NEXT_PUBLIC_BFF_URL=https://api.paypay.iddqd.in`
+- `BTCPAY_URL=https://pay.iddqd.in`
+- `TRUST_PROXY=1`
+- `NODE_ENV=production`
+- Add them to `deploy/docker/.env` (or your deployment-specific `.env`).
+
+## BTCPay API Key
+- Create a key in **BTCPay Server → Account → API Keys → Create new**.
+- Grant the minimum permissions required for a merchant workflow:
+  - `btcpay.store.cancreateinvoice` — create invoices (required).
+  - `btcpay.store.canviewinvoices` — view invoices for UI/status pages.
+  - `btcpay.store.webhooks.canmodifywebhooks` — manage webhooks from our UI (if needed).
+  - `btcpay.store.canviewstoresettings` — read store settings when necessary.
+- Do **not** grant server-wide permissions such as `btcpay.server.canmodifyserversettings`.
+
+## Operational Checklist
+- `curl -I https://api.paypay.iddqd.in/healthz` returns **200**.
+- `curl -i https://api.paypay.iddqd.in/csrf-token` returns **200** and includes `Set-Cookie: __Host-...; Secure; SameSite=Lax; Path=/`.

--- a/apps/bff/Dockerfile
+++ b/apps/bff/Dockerfile
@@ -22,6 +22,8 @@ FROM node:22-alpine AS runner
 ENV NODE_ENV=production
 WORKDIR /opt/app
 COPY --from=build /opt/app ./
+COPY apps/bff/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 USER node
 EXPOSE 4000
-CMD ["node", "dist/main.js"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/apps/bff/docker-entrypoint.sh
+++ b/apps/bff/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+CANDIDATES="
+dist/main.js
+dist/src/main.js
+apps/bff/dist/main.js
+dist/apps/bff/main.js
+main.js
+"
+
+cd /opt/app 2>/dev/null || true
+
+for p in $CANDIDATES; do
+  if [ -f "$p" ]; then
+    echo "[entrypoint] Starting: node $p"
+    exec node "$p"
+  fi
+done
+
+echo "[entrypoint] ERROR: could not locate main.js in any of: $CANDIDATES" >&2
+ls -lah .
+find . -maxdepth 4 -name main.js -print || true
+exit 1

--- a/apps/bff/src/main.ts
+++ b/apps/bff/src/main.ts
@@ -37,20 +37,19 @@ async function bootstrap() {
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true }));
 
   const frontendOrigin = configService.get<string>('FRONTEND_ORIGIN');
-  const paypayDomain = configService.get<string>('PAYPAY_DOMAIN');
-  const computedOrigin = frontendOrigin || (paypayDomain ? `https://${paypayDomain}` : undefined);
+  const corsOrigins = frontendOrigin ? [frontendOrigin] : [];
   app.enableCors({
-    origin: computedOrigin ? [computedOrigin] : false,
+    origin: corsOrigins.length > 0 ? corsOrigins : false,
     credentials: true,
-    methods: ['POST', 'GET'],
-    allowedHeaders: ['Content-Type', 'X-CSRF-Token', 'x-csrf-token', 'Accept'],
-    optionsSuccessStatus: 204
+    methods: ['GET', 'POST'],
+    allowedHeaders: ['Content-Type', 'X-CSRF-Token', 'Accept']
   });
 
   const httpAdapter = app.getHttpAdapter();
   const type = httpAdapter.getType();
   const instance = httpAdapter.getInstance();
-  const trustProxyValue = parseTrustProxy(configService.get<string>('TRUST_PROXY'));
+  const trustProxyRaw = configService.get<string>('TRUST_PROXY') ?? '1';
+  const trustProxyValue = parseTrustProxy(trustProxyRaw);
 
   if (type === 'express' && typeof (instance as any).set === 'function') {
     (instance as any).set('trust proxy', trustProxyValue);


### PR DESCRIPTION
## Summary
- add a Docker entrypoint script that locates the compiled NestJS main bundle before booting the BFF
- configure the runtime Docker image to use the entrypoint and keep NODE_ENV=production
- tighten CORS and trust proxy defaults and document required secrets, BTCPay API keys, and ops checklist in the README

## Testing
- pnpm --filter bff build

------
https://chatgpt.com/codex/tasks/task_e_68d962585e54832f8360e5196905c54d