### PR TITLE
Fix API base path usage and invoice route prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ PayPay is a monorepo housing the Next.js merchant portal, NestJS BFF, and a type
 2. Open `infra/env/.env` and set the required values:
    - `PAYPAY_DOMAIN` / `PAYPAY_API_DOMAIN` – public domains that end-users will visit.
    - `CADDY_ADMIN_EMAIL` – email for ACME certificate management.
-   - `NEXT_PUBLIC_BFF_URL` – must be `https://<PAYPAY_API_DOMAIN>` so the frontend CSP allows calls to the BFF.
-  - `NEXT_PUBLIC_API_BASE` – defaults to `https://<PAYPAY_API_DOMAIN>/api`; adjust if you expose the API elsewhere.
+  - `NEXT_PUBLIC_BFF_URL` – must be `https://<PAYPAY_API_DOMAIN>` so the frontend CSP allows calls to the BFF.
+  - `NEXT_PUBLIC_API_BASE` – defaults to `/api`; adjust only if the BFF is mounted elsewhere behind your proxy.
    - `FRONTEND_ORIGIN` – must be `https://<PAYPAY_DOMAIN>` so the BFF CORS policy matches the UI.
    - `BTCPAY_URL` / `BTCPAY_BASE_URL`, `BTCPAY_API_KEY`, `BTCPAY_WEBHOOK_SECRET`, `STORE_ID` – credentials for your BTCPay Server tenant.
    - `JWT_ACCESS_TOKEN_SECRET` and `JWT_REFRESH_TOKEN_SECRET` – secrets for issuing user tokens.
@@ -93,4 +93,4 @@ You can also spin up the Docker stack locally with the same production instructi
 
 ## Operational Checklist
 - `curl -I https://api.paypay.iddqd.in/healthz` returns **200**.
-- `curl -i https://api.paypay.iddqd.in/csrf-token` returns **200** and includes `Set-Cookie: __Host-...; Secure; SameSite=Lax; Path=/`.
+- `curl -i https://api.paypay.iddqd.in/api/auth/csrf-token` returns **200** and includes `Set-Cookie: __Host-...; Secure; SameSite=Lax; Path=/`.

--- a/apps/bff/src/invoices/invoices.controller.ts
+++ b/apps/bff/src/invoices/invoices.controller.ts
@@ -11,7 +11,7 @@ import { ConfigService } from '@nestjs/config';
 import { BtcpayService } from '../btcpay/btcpay.service';
 import { CreateInvoiceDto } from './dto/create-invoice.dto';
 
-@Controller('api/invoices')
+@Controller('invoices')
 export class InvoicesController {
   constructor(
     private readonly btcpayService: BtcpayService,

--- a/apps/bff/src/main.ts
+++ b/apps/bff/src/main.ts
@@ -39,7 +39,7 @@ async function bootstrap() {
   const frontendOrigin = configService.get<string>('FRONTEND_ORIGIN');
   const corsOrigins = frontendOrigin ? [frontendOrigin] : [];
   app.enableCors({
-    origin: corsOrigins.length > 0 ? corsOrigins : false,
+    origin: corsOrigins,
     credentials: true,
     methods: ['GET', 'POST'],
     allowedHeaders: ['Content-Type', 'X-CSRF-Token', 'Accept']

--- a/apps/frontend/app/(auth)/client-actions.ts
+++ b/apps/frontend/app/(auth)/client-actions.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { z } from 'zod';
+import { getApiBasePath, getBffApiBaseUrl, getBffOrigin } from '../../lib/bff';
 
 export type AuthFormStateBase = {
   fieldErrors?: Record<string, string[]>;
@@ -20,21 +21,20 @@ const credentialsSchema = z.object({
 
 type Credentials = z.infer<typeof credentialsSchema>;
 
-function getBffBaseUrl(): string {
-  const envUrl = process.env.NEXT_PUBLIC_BFF_URL;
-  if (envUrl && envUrl.trim().length > 0) {
-    return envUrl.replace(/\/$/, '');
+function resolveApiBaseUrl(): string {
+  const baseUrl = getBffApiBaseUrl();
+  const origin = getBffOrigin();
+
+  if (!origin) {
+    const basePath = getApiBasePath();
+    return basePath.replace(/\/$/, '');
   }
 
-  if (typeof window !== 'undefined') {
-    return window.location.origin.replace(/\/$/, '');
-  }
-
-  return 'http://localhost:4000';
+  return baseUrl.replace(/\/$/, '');
 }
 
 async function fetchCsrfToken(baseUrl: string): Promise<string> {
-  const response = await fetch(`${baseUrl}/api/auth/csrf-token`, {
+  const response = await fetch(`${baseUrl}/auth/csrf-token`, {
     method: 'GET',
     credentials: 'include',
     cache: 'no-store'
@@ -53,7 +53,7 @@ async function fetchCsrfToken(baseUrl: string): Promise<string> {
 }
 
 async function performAuthRequest(endpoint: 'signup' | 'login', body: Credentials): Promise<AuthActionResult> {
-  const baseUrl = getBffBaseUrl();
+  const baseUrl = resolveApiBaseUrl();
 
   let csrfToken: string;
   try {
@@ -65,11 +65,11 @@ async function performAuthRequest(endpoint: 'signup' | 'login', body: Credential
 
   let response: Response;
   try {
-    response = await fetch(`${baseUrl}/api/auth/${endpoint}`, {
+    response = await fetch(`${baseUrl}/auth/${endpoint}`, {
       method: 'POST',
       headers: {
-        'content-type': 'application/json',
-        'x-csrf-token': csrfToken
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrfToken
       },
       body: JSON.stringify(body),
       cache: 'no-store',

--- a/apps/frontend/app/invoices/new/new-invoice-form.tsx
+++ b/apps/frontend/app/invoices/new/new-invoice-form.tsx
@@ -2,9 +2,10 @@
 
 import { useState, type FormEvent } from 'react';
 import { Button } from '../../../components/ui/button';
+import { getApiBasePath, getBffOrigin } from '../../../lib/bff';
 
 type Props = {
-  apiBase: string;
+  apiBaseUrl: string;
 };
 
 type RequestState =
@@ -28,7 +29,7 @@ function safeJsonParse<T = unknown>(raw: string): T | undefined {
   }
 }
 
-export function NewInvoiceForm({ apiBase }: Props) {
+export function NewInvoiceForm({ apiBaseUrl }: Props) {
   const [amount, setAmount] = useState('');
   const [currency, setCurrency] = useState('BTC');
   const [metadata, setMetadata] = useState('');
@@ -48,7 +49,14 @@ export function NewInvoiceForm({ apiBase }: Props) {
         payload.metadata = parsed;
       }
 
-      const sanitizedBase = apiBase.replace(/\/$/, '');
+      let sanitizedBase = apiBaseUrl.replace(/\/$/, '');
+      if (!sanitizedBase.startsWith('http')) {
+        const origin = getBffOrigin();
+        if (origin) {
+          sanitizedBase = `${origin}${getApiBasePath()}`.replace(/\/$/, '');
+        }
+      }
+
       const csrfResponse = await fetch(`${sanitizedBase}/auth/csrf-token`, {
         method: 'GET',
         credentials: 'include',

--- a/apps/frontend/app/invoices/new/page.tsx
+++ b/apps/frontend/app/invoices/new/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Button } from '../../../components/ui/button';
+import { getBffApiBaseUrl } from '../../../lib/bff';
 import { NewInvoiceForm } from './new-invoice-form';
 
 export const metadata: Metadata = {
@@ -8,7 +9,7 @@ export const metadata: Metadata = {
 };
 
 export default function NewInvoicePage() {
-  const apiBase = process.env.NEXT_PUBLIC_API_BASE ?? '/api';
+  const apiBaseUrl = getBffApiBaseUrl();
 
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
@@ -19,7 +20,7 @@ export default function NewInvoicePage() {
           generate a payable invoice for your configured BTCPay store.
         </p>
       </div>
-      <NewInvoiceForm apiBase={apiBase} />
+      <NewInvoiceForm apiBaseUrl={apiBaseUrl} />
       <div className="flex items-center justify-between border-t pt-4 text-sm text-muted-foreground">
         <span>Need to inspect health?</span>
         <Button asChild variant="link" className="h-auto p-0">

--- a/apps/frontend/lib/bff.ts
+++ b/apps/frontend/lib/bff.ts
@@ -1,0 +1,64 @@
+function sanitizeOrigin(raw?: string | null): string | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const url = new URL(trimmed);
+    return url.origin;
+  } catch {
+    return trimmed.replace(/\/$/, '');
+  }
+}
+
+function sanitizeBasePath(raw?: string | null): string {
+  const fallback = '/api';
+  if (!raw) {
+    return fallback;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+  const withLeading = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  return withLeading.replace(/\/+$/, '') || fallback;
+}
+
+function resolveRuntimeOrigin(): string | undefined {
+  const envOrigin = sanitizeOrigin(process.env.NEXT_PUBLIC_BFF_URL);
+  if (envOrigin) {
+    return envOrigin;
+  }
+
+  if (typeof window !== 'undefined') {
+    return sanitizeOrigin(window.location.origin);
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    return 'http://localhost:4000';
+  }
+
+  return undefined;
+}
+
+export function getApiBasePath(): string {
+  return sanitizeBasePath(process.env.NEXT_PUBLIC_API_BASE);
+}
+
+export function getBffOrigin(): string | undefined {
+  return resolveRuntimeOrigin();
+}
+
+export function getBffApiBaseUrl(): string {
+  const origin = resolveRuntimeOrigin();
+  const basePath = getApiBasePath();
+
+  if (!origin) {
+    return basePath;
+  }
+
+  return `${origin}${basePath}`;
+}

--- a/apps/frontend/lib/utils.ts
+++ b/apps/frontend/lib/utils.ts
@@ -1,17 +1,20 @@
-import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+import { getApiBasePath } from './bff';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+const apiBasePath = getApiBasePath();
+
 export const apiRoutes = {
   auth: {
-    login: "/api/auth/login",
-    signup: "/api/auth/signup",
-    refresh: "/api/auth/refresh"
+    login: `${apiBasePath}/auth/login`,
+    signup: `${apiBasePath}/auth/signup`,
+    refresh: `${apiBasePath}/auth/refresh`
   },
   organizations: {
-    list: "/api/organizations"
+    list: `${apiBasePath}/organizations`
   }
 };

--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -12,8 +12,8 @@ CADDY_ADMIN_EMAIL=
 # --- Frontend (Next.js) ---
 # Public origin of the BFF; must be https://<PAYPAY_API_DOMAIN>
 NEXT_PUBLIC_BFF_URL=
-# Base path used by the frontend when calling the BFF (typically https://<PAYPAY_API_DOMAIN>/api)
-NEXT_PUBLIC_API_BASE=
+# Base path used by the frontend when calling the BFF (typically just /api)
+NEXT_PUBLIC_API_BASE=/api
 
 # --- BFF (NestJS) ---
 # Browser origin allowed by CORS; must be https://<PAYPAY_DOMAIN>


### PR DESCRIPTION
## Summary
- align the frontend API base configuration on `/api` and centralize BFF URL resolution helpers
- update auth and invoice flows to call `${NEXT_PUBLIC_BFF_URL}${NEXT_PUBLIC_API_BASE}` endpoints with credentials included
- rely on NestJS' global `/api` prefix for invoices, tighten documented env defaults, and keep the intended CORS/trust proxy settings

## Testing
- pnpm --filter frontend lint *(fails: ESLint config is not yet migrated to eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d96680ef64832fb769ea9bf90ef0a5