### PR TITLE
Fix TypeORM migration naming to use timestamp format

### DIFF
--- a/apps/bff/docker-entrypoint.sh
+++ b/apps/bff/docker-entrypoint.sh
@@ -1,44 +1,5 @@
-#!/bin/sh
-set -e
+#!/usr/bin/env sh
+set -euo pipefail
 
-CANDIDATES="
-dist/main.js
-dist/src/main.js
-apps/bff/dist/main.js
-dist/apps/bff/main.js
-main.js
-"
-
-cd /opt/app 2>/dev/null || true
-
-for p in $CANDIDATES; do
-  if [ -f "$p" ]; then
-    MIGRATION_SCRIPT=""
-    for m in \
-      /opt/app/dist/src/scripts/migrate.js \
-      /opt/app/dist/scripts/migrate.js \
-      /opt/app/apps/bff/dist/src/scripts/migrate.js \
-      /opt/app/apps/bff/dist/scripts/migrate.js; do
-      if [ -f "$m" ]; then
-        MIGRATION_SCRIPT="$m"
-        break
-      fi
-    done
-
-    if [ -n "$MIGRATION_SCRIPT" ]; then
-      echo "[entrypoint] Running DB migrations..."
-      node "$MIGRATION_SCRIPT" || {
-        echo "[entrypoint] Migration failed";
-        exit 1;
-      }
-    fi
-
-    echo "[entrypoint] Starting: node $p"
-    exec node "$p"
-  fi
-done
-
-echo "[entrypoint] ERROR: could not locate main.js in any of: $CANDIDATES" >&2
-ls -lah .
-find . -maxdepth 4 -name main.js -print || true
-exit 1
+node dist/scripts/migrate.js
+node dist/main.js

--- a/apps/bff/package.json
+++ b/apps/bff/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "nest build",
+    "migrate": "node dist/scripts/migrate.js",
     "start": "node dist/main.js",
     "dev": "nest start --watch",
     "lint": "eslint \"src/**/*.ts\"",
@@ -11,7 +12,7 @@
     "test": "jest --config jest.config.ts",
     "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js -d apps/bff/src/database/data-source.ts",
     "migration:generate": "pnpm typeorm migration:generate apps/bff/src/migrations/Auto",
-    "migration:run": "node dist/src/scripts/migrate.js",
+    "migration:run": "node dist/scripts/migrate.js",
     "migration:revert": "pnpm typeorm migration:revert"
   },
   "dependencies": {

--- a/apps/bff/src/database/data-source.ts
+++ b/apps/bff/src/database/data-source.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import { DataSource } from 'typeorm';
+import * as path from 'path';
 
 export const AppDataSource = new DataSource({
   type: 'postgres',
@@ -10,7 +11,10 @@ export const AppDataSource = new DataSource({
   database: process.env.POSTGRES_DB || 'paypay',
   ssl: false,
   entities: [__dirname + '/../**/*.entity.{js,ts}'],
-  migrations: [__dirname + '/../migrations/*.{js,ts}'],
+  migrations:
+    process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test'
+      ? ['src/migrations/*.ts']
+      : [path.join(__dirname, '../migrations/*.js')],
   migrationsTableName: 'migrations',
   synchronize: false,
   logging: ['warn', 'error']

--- a/apps/bff/src/migrations/1727563200000-InitSchema.ts
+++ b/apps/bff/src/migrations/1727563200000-InitSchema.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class InitSchema0001 implements MigrationInterface {
-  name = 'InitSchema0001';
+export class InitSchema1727563200000 implements MigrationInterface {
+  name = 'InitSchema1727563200000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('CREATE EXTENSION IF NOT EXISTS "pgcrypto"');

--- a/apps/bff/tsconfig.build.json
+++ b/apps/bff/tsconfig.build.json
@@ -6,5 +6,5 @@
     "declaration": false,
     "sourceMap": false
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "src/migrations/**/*"]
 }


### PR DESCRIPTION
## Summary
- rename the initial migration to the 1727563200000 timestamp-based class and file naming convention
- update the TypeORM data source configuration to resolve compiled migrations in dist and fall back to ts sources for dev
- include migrations in the build output, streamline the Docker entrypoint, and align scripts for running compiled migrations

## Testing
- pnpm --filter bff build

------
https://chatgpt.com/codex/tasks/task_e_68d97296f2e0832f856821a5c4d9946d