### PR TITLE
refine btcpay onboarding security flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,12 @@ PayPay is a monorepo housing the Next.js merchant portal, NestJS BFF, and a type
    - `CADDY_ADMIN_EMAIL` – email for ACME certificate management.
   - `NEXT_PUBLIC_BFF_URL` – must be `https://<PAYPAY_API_DOMAIN>` so the frontend CSP allows calls to the BFF.
   - `NEXT_PUBLIC_API_BASE` – defaults to `/api`; adjust only if the BFF is mounted elsewhere behind your proxy.
-   - `FRONTEND_ORIGIN` – must be `https://<PAYPAY_DOMAIN>` so the BFF CORS policy matches the UI.
-   - `BTCPAY_URL` / `BTCPAY_BASE_URL`, `BTCPAY_API_KEY`, `BTCPAY_WEBHOOK_SECRET`, `STORE_ID` – credentials for your BTCPay Server tenant.
+  - `FRONTEND_ORIGIN` – must be `https://<PAYPAY_DOMAIN>` so the BFF CORS policy matches the UI.
+  - `BTCPAY_URL` – base URL of your BTCPay Server instance.
+  - `BTCPAY_ADMIN_API_KEY` – server-admin API key used for automated onboarding.
+  - `BTCPAY_MASTER_KEY` – base64-encoded 32-byte master key for envelope encryption.
+- `BTCPAY_WEBHOOK_URL` – public HTTPS endpoint for webhook deliveries (e.g. `https://$PAYPAY_API_DOMAIN/api/hooks/btcpay`).
+  - `BTCPAY_HEALTH_STORE_ID` / `BTCPAY_HEALTH_API_KEY` – optional credentials for the internal BTCPay health probe.
    - `JWT_ACCESS_TOKEN_SECRET` and `JWT_REFRESH_TOKEN_SECRET` – secrets for issuing user tokens.
    - Database/cache settings (`POSTGRES_*`, `REDIS_*`) – defaults work out of the box but can be overridden.
 3. From the server, build and start the stack (no Node.js or pnpm required on the host):
@@ -66,30 +70,32 @@ You can also spin up the Docker stack locally with the same production instructi
   openssl rand -hex 64  # JWT_REFRESH_TOKEN_SECRET
   ```
 
-### BTCPay webhook secret
-- Validates webhook authenticity from BTCPay Server.
+### Envelope encryption master key
+- Used to wrap store-scoped Data Encryption Keys (DEKs) for BTCPay API keys and webhook secrets.
+- Must be a 256-bit value encoded in base64.
 - Generate it with:
   ```bash
-  openssl rand -hex 32
+  openssl rand -base64 32
   ```
-- When creating a webhook in BTCPay, set this value in the **Secret** field.
+- Set the result as `BTCPAY_MASTER_KEY` in the BFF environment.
 
 ### Mandatory environment variables
 - `FRONTEND_ORIGIN=https://paypay.iddqd.in`
 - `NEXT_PUBLIC_BFF_URL=https://api.paypay.iddqd.in`
 - `BTCPAY_URL=https://pay.iddqd.in`
+- `BTCPAY_ADMIN_API_KEY=<server-admin-api-key>`
+- `BTCPAY_MASTER_KEY=<base64-32-byte-master-key>`
+- `BTCPAY_WEBHOOK_URL=https://api.paypay.iddqd.in/api/hooks/btcpay`
 - `TRUST_PROXY=1`
 - `NODE_ENV=production`
 - Add them to `deploy/docker/.env` (or your deployment-specific `.env`).
 
-## BTCPay API Key
-- Create a key in **BTCPay Server → Account → API Keys → Create new**.
-- Grant the minimum permissions required for a merchant workflow:
-  - `btcpay.store.cancreateinvoice` — create invoices (required).
-  - `btcpay.store.canviewinvoices` — view invoices for UI/status pages.
-  - `btcpay.store.webhooks.canmodifywebhooks` — manage webhooks from our UI (if needed).
-  - `btcpay.store.canviewstoresettings` — read store settings when necessary.
-- Do **not** grant server-wide permissions such as `btcpay.server.canmodifyserversettings`.
+If your edge or proxy strips the `/api` prefix before reaching the BFF, configure `BTCPAY_WEBHOOK_URL` without `/api` and align the routing rules accordingly.
+
+## BTCPay admin API key
+- Create a server-admin API key in **BTCPay Server → Server Settings → Access Tokens**.
+- Grant only `btcpay.server.canmanageusers`; the BFF provisions stores using temporary user-scoped API keys with `btcpay.store.canmodifystoresettings` and then replaces them with permanent store-scoped keys.
+- Tenant-facing API keys are generated per store with the minimal permissions listed in the BTCPay eCommerce Integration Guide. Keys and webhook secrets are envelope encrypted and never exposed to the frontend.
 
 ## Operational Checklist
 - `curl -I https://api.paypay.iddqd.in/healthz` returns **200**.

--- a/apps/bff/package.json
+++ b/apps/bff/package.json
@@ -24,6 +24,7 @@
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/typeorm": "^11.0.0",
     "@paypay/sdk": "workspace:*",
+    "axios": "^1.7.7",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "cookie-parser": "^1.4.7",

--- a/apps/bff/src/app.module.ts
+++ b/apps/bff/src/app.module.ts
@@ -7,11 +7,16 @@ import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { CsrfGuard } from './auth/csrf.guard';
 import { LoggerModule } from 'nestjs-pino';
 import { BtcpayModule } from './btcpay/btcpay.module';
-import { InvoicesModule } from './invoices/invoices.module';
 import { HealthModule } from './health/health.module';
 import { AuthModule } from './auth/auth.module';
 import { UserEntity } from './auth/entities/user.entity';
 import { RefreshTokenEntity } from './auth/entities/refresh-token.entity';
+import { TenantEntity } from './tenants/entities/tenant.entity';
+import { StoreEntity } from './tenants/entities/store.entity';
+import { AuditLogEntity } from './tenants/entities/audit-log.entity';
+import { IdempotencyKeyEntity } from './tenants/entities/idempotency-key.entity';
+import { TenantsModule } from './tenants/tenants.module';
+import { HooksModule } from './hooks/hooks.module';
 
 @Module({
   imports: [
@@ -27,7 +32,9 @@ import { RefreshTokenEntity } from './auth/entities/refresh-token.entity';
             'res.headers["set-cookie"]',
             'req.body.password',
             'req.body.refreshToken',
-            'req.body.token'
+            'req.body.token',
+            'req.headers["btcpay-sig"]',
+            'req.headers["btcpay-delivery"]'
           ],
           remove: true
         }
@@ -44,7 +51,14 @@ import { RefreshTokenEntity } from './auth/entities/refresh-token.entity';
           return {
             type: 'sqlite',
             database,
-            entities: [UserEntity, RefreshTokenEntity],
+            entities: [
+              UserEntity,
+              RefreshTokenEntity,
+              TenantEntity,
+              StoreEntity,
+              AuditLogEntity,
+              IdempotencyKeyEntity
+            ],
             synchronize: true,
             dropSchema: true,
             logging: false
@@ -53,7 +67,14 @@ import { RefreshTokenEntity } from './auth/entities/refresh-token.entity';
 
         const baseOptions = {
           type: 'postgres',
-          entities: [UserEntity, RefreshTokenEntity],
+          entities: [
+            UserEntity,
+            RefreshTokenEntity,
+            TenantEntity,
+            StoreEntity,
+            AuditLogEntity,
+            IdempotencyKeyEntity
+          ],
           synchronize: false,
           migrations: ['dist/migrations/*.js'],
           migrationsRun: true
@@ -96,8 +117,9 @@ import { RefreshTokenEntity } from './auth/entities/refresh-token.entity';
     }),
     AuthModule,
     BtcpayModule,
-    InvoicesModule,
-    HealthModule
+    HealthModule,
+    TenantsModule,
+    HooksModule
   ],
   providers: [
     {

--- a/apps/bff/src/auth/csrf.guard.ts
+++ b/apps/bff/src/auth/csrf.guard.ts
@@ -21,6 +21,15 @@ export class CsrfGuard implements CanActivate {
       return true;
     }
 
+    const path = `${request.baseUrl ?? ''}${request.path ?? ''}` || request.originalUrl || '';
+    const hasBtcpaySignature = typeof request.header('btcpay-sig') === 'string';
+    if (
+      hasBtcpaySignature &&
+      (path.startsWith('/hooks/btcpay') || path.startsWith('/api/hooks/btcpay'))
+    ) {
+      return true;
+    }
+
     const headerToken = request.header('x-csrf-token');
     const cookieToken = request.cookies?.[CSRF_TOKEN_COOKIE_NAME];
 

--- a/apps/bff/src/btcpay/btcpay.module.ts
+++ b/apps/bff/src/btcpay/btcpay.module.ts
@@ -1,8 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { createBTCPayClient } from '@paypay/sdk';
 import { BtcpayService } from './btcpay.service';
-import { BTCPAY_CLIENT, BTCPAY_CONFIG, type BtcpayConfig } from './btcpay.tokens';
+import { BTCPAY_CONFIG, type BtcpayConfig } from './btcpay.tokens';
 
 @Module({
   providers: [
@@ -11,15 +10,12 @@ import { BTCPAY_CLIENT, BTCPAY_CONFIG, type BtcpayConfig } from './btcpay.tokens
       provide: BTCPAY_CONFIG,
       useFactory: (config: ConfigService): BtcpayConfig => ({
         baseUrl: config.getOrThrow<string>('BTCPAY_URL'),
-        apiKey: config.getOrThrow<string>('BTCPAY_API_KEY')
+        adminApiKey: config.getOrThrow<string>('BTCPAY_ADMIN_API_KEY'),
+        webhookUrl: config.getOrThrow<string>('BTCPAY_WEBHOOK_URL'),
+        healthStoreId: config.get<string>('BTCPAY_HEALTH_STORE_ID') ?? undefined,
+        healthApiKey: config.get<string>('BTCPAY_HEALTH_API_KEY') ?? undefined
       }),
       inject: [ConfigService]
-    },
-    {
-      provide: BTCPAY_CLIENT,
-      useFactory: (cfg: BtcpayConfig) =>
-        createBTCPayClient({ baseUrl: cfg.baseUrl, apiKey: cfg.apiKey }),
-      inject: [BTCPAY_CONFIG]
     }
   ],
   exports: [BtcpayService]

--- a/apps/bff/src/btcpay/btcpay.service.ts
+++ b/apps/bff/src/btcpay/btcpay.service.ts
@@ -1,39 +1,251 @@
-import { Inject, Injectable } from '@nestjs/common';
-import type {
-  BTCPayClient,
-  CreateInvoiceRequest,
-  Invoice,
-  Store
-} from '@paypay/sdk';
-import { BTCPAY_CLIENT, BTCPAY_CONFIG, type BtcpayConfig } from './btcpay.tokens';
+import {
+  BadGatewayException,
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+  UnauthorizedException
+} from '@nestjs/common';
+import axios, { AxiosError, AxiosInstance } from 'axios';
+import { BTCPAY_CONFIG, type BtcpayConfig } from './btcpay.tokens';
 import { BTCPAY_MINIMAL_PERMISSIONS } from './btcpay.constants';
+
+export interface CreateInvoiceRequest {
+  amount: number;
+  currency: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface ApiKeyResponse {
+  apiKey: string;
+  permissions: string[];
+}
+
+interface WebhookResponse {
+  id: string;
+  secret?: string | null;
+}
+
+interface StoreResponse {
+  id: string;
+  name?: string;
+}
+
+interface UserResponse {
+  id: string;
+  email: string;
+}
 
 @Injectable()
 export class BtcpayService {
-  constructor(
-    @Inject(BTCPAY_CLIENT) private readonly client: BTCPayClient,
-    @Inject(BTCPAY_CONFIG) private readonly config: BtcpayConfig
-  ) {}
+  private readonly logger = new Logger(BtcpayService.name, { timestamp: false });
 
-  listStores(): Promise<Store[]> {
-    return this.client.listStores();
+  constructor(@Inject(BTCPAY_CONFIG) private readonly config: BtcpayConfig) {}
+
+  private normaliseBaseUrl(url: string): string {
+    return url.endsWith('/') ? url.slice(0, -1) : url;
   }
 
-  createInvoice(storeId: string, payload: CreateInvoiceRequest): Promise<Invoice> {
-    return this.client.createInvoice(storeId, payload);
+  private getBaseUrl(host?: string): string {
+    return this.normaliseBaseUrl(host ?? this.config.baseUrl);
   }
 
-  getInvoice(storeId: string, invoiceId: string): Promise<Invoice> {
-    return this.client.getInvoice(storeId, invoiceId);
+  resolveBaseUrl(host?: string): string {
+    return this.getBaseUrl(host);
   }
 
-  buildAuthorizeUserUrl(params: { storeId: string; applicationName: string; redirectUrl: string }): string {
-    const baseUrl = new URL(this.config.baseUrl);
+  private createHttp(baseUrl: string, headers: Record<string, string>): AxiosInstance {
+    return axios.create({
+      baseURL: this.getBaseUrl(baseUrl),
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...headers
+      },
+      timeout: 15_000
+    });
+  }
+
+  private maskError(error: unknown): never {
+    if (axios.isAxiosError(error)) {
+      const err = error as AxiosError<{ message?: string; errors?: unknown }>;
+      const code = err.response?.status ?? 500;
+      const body = err.response?.data;
+      this.logger.error(`BTCPay request failed with status ${code}`, body ? JSON.stringify(body) : undefined);
+      const message = body?.message ?? 'BTCPay request failed';
+      switch (code) {
+        case 400:
+          throw new BadRequestException(message, { cause: error as Error });
+        case 401:
+          throw new UnauthorizedException(message, { cause: error as Error });
+        case 403:
+          throw new ForbiddenException(message, { cause: error as Error });
+        case 404:
+          throw new NotFoundException(message, { cause: error as Error });
+        default:
+          throw new BadGatewayException('BTCPay request failed', { cause: error as Error });
+      }
+    }
+    throw new InternalServerErrorException('Unexpected BTCPay error', { cause: error as Error });
+  }
+
+  async createUser(
+    host: string | undefined,
+    payload: { email: string; password?: string; name?: string; sendInvitationEmail?: boolean }
+  ): Promise<UserResponse> {
+    const http = this.createHttp(host ?? this.config.baseUrl, {
+      Authorization: `token ${this.config.adminApiKey}`
+    });
+    try {
+      const body: Record<string, unknown> = {
+        email: payload.email,
+        name: payload.name,
+        sendInvitationEmail: payload.sendInvitationEmail ?? false
+      };
+      if (payload.password) {
+        body.password = payload.password;
+      }
+      const { data } = await http.post<UserResponse>('/api/v1/users', body);
+      return data;
+    } catch (error) {
+      return this.maskError(error);
+    }
+  }
+
+  async createUserApiKey(host: string | undefined, email: string, storeId: string, includePullPayments = false): Promise<ApiKeyResponse> {
+    const permissions = this.buildStorePermissions(storeId, includePullPayments);
+    const http = this.createHttp(host ?? this.config.baseUrl, {
+      Authorization: `token ${this.config.adminApiKey}`
+    });
+    try {
+      const { data } = await http.post<ApiKeyResponse>(`/api/v1/users/${encodeURIComponent(email)}/api-keys`, {
+        label: `Store ${storeId} key`,
+        permissions
+      });
+      return data;
+    } catch (error) {
+      return this.maskError(error);
+    }
+  }
+
+  async createUserApiKeyUnscoped(
+    host: string | undefined,
+    email: string,
+    permissions: string[],
+    label = 'Temporary key'
+  ): Promise<ApiKeyResponse> {
+    const http = this.createHttp(host ?? this.config.baseUrl, {
+      Authorization: `token ${this.config.adminApiKey}`
+    });
+    try {
+      const { data } = await http.post<ApiKeyResponse>(`/api/v1/users/${encodeURIComponent(email)}/api-keys`, {
+        label,
+        permissions
+      });
+      return data;
+    } catch (error) {
+      return this.maskError(error);
+    }
+  }
+
+  async createStoreWithUserToken(host: string | undefined, apiKey: string, payload: { name: string }): Promise<StoreResponse> {
+    const http = this.createHttp(host ?? this.config.baseUrl, {
+      Authorization: `token ${apiKey}`
+    });
+    try {
+      const { data } = await http.post<StoreResponse>('/api/v1/stores', payload);
+      return data;
+    } catch (error) {
+      return this.maskError(error);
+    }
+  }
+
+  async deleteApiKey(host: string | undefined, apiKey: string): Promise<void> {
+    const http = this.createHttp(host ?? this.config.baseUrl, {
+      Authorization: `token ${this.config.adminApiKey}`
+    });
+    try {
+      await http.delete(`/api/v1/api-keys/${encodeURIComponent(apiKey)}`);
+    } catch (error) {
+      this.maskError(error);
+    }
+  }
+
+  async removeStoreUser(host: string | undefined, storeId: string, idOrEmail: string): Promise<void> {
+    const http = this.createHttp(host ?? this.config.baseUrl, {
+      Authorization: `token ${this.config.adminApiKey}`
+    });
+    try {
+      await http.delete(`/api/v1/stores/${storeId}/users/${encodeURIComponent(idOrEmail)}`);
+    } catch (error) {
+      this.maskError(error);
+    }
+  }
+
+  async registerWebhook(host: string | undefined, apiKey: string, storeId: string): Promise<WebhookResponse> {
+    const http = this.createHttp(host ?? this.config.baseUrl, {
+      Authorization: `token ${apiKey}`
+    });
+    try {
+      const { data } = await http.post<WebhookResponse>(`/api/v1/stores/${storeId}/webhooks`, {
+        url: this.config.webhookUrl
+      });
+      return data;
+    } catch (error) {
+      return this.maskError(error);
+    }
+  }
+
+  async createInvoice(host: string | undefined, apiKey: string, storeId: string, payload: CreateInvoiceRequest) {
+    const http = this.createHttp(host ?? this.config.baseUrl, {
+      Authorization: `token ${apiKey}`
+    });
+    try {
+      const { data } = await http.post(`/api/v1/stores/${storeId}/invoices`, payload);
+      return data;
+    } catch (error) {
+      return this.maskError(error);
+    }
+  }
+
+  async getStore(host: string | undefined, apiKey: string, storeId: string) {
+    const http = this.createHttp(host ?? this.config.baseUrl, {
+      Authorization: `token ${apiKey}`
+    });
+    try {
+      const { data } = await http.get(`/api/v1/stores/${storeId}`);
+      return data;
+    } catch (error) {
+      return this.maskError(error);
+    }
+  }
+
+  async healthProbe(): Promise<void> {
+    const { healthApiKey, healthStoreId } = this.config;
+    if (!healthApiKey || !healthStoreId) {
+      return;
+    }
+    await this.getStore(undefined, healthApiKey, healthStoreId);
+  }
+
+  buildAuthorizeUserUrl(params: { storeId: string; applicationName: string; redirectUrl: string; host?: string }): string {
+    const baseUrl = new URL(this.getBaseUrl(params.host));
     const authorizeUrl = new URL('/api-keys/authorize', baseUrl);
     authorizeUrl.searchParams.set('applicationName', params.applicationName);
     authorizeUrl.searchParams.set('redirectUrl', params.redirectUrl);
     authorizeUrl.searchParams.set('storeId', params.storeId);
     authorizeUrl.searchParams.set('permissions', BTCPAY_MINIMAL_PERMISSIONS.join(','));
     return authorizeUrl.toString();
+  }
+
+  private buildStorePermissions(storeId: string, includePullPayments: boolean): string[] {
+    const scoped = BTCPAY_MINIMAL_PERMISSIONS.map((permission) => `${permission}:${storeId}`);
+    if (!includePullPayments) {
+      return scoped.filter((permission) => !permission.startsWith('btcpay.store.cancreatenonapprovedpullpayments'));
+    }
+    return scoped;
   }
 }

--- a/apps/bff/src/btcpay/btcpay.tokens.ts
+++ b/apps/bff/src/btcpay/btcpay.tokens.ts
@@ -1,7 +1,9 @@
-export const BTCPAY_CLIENT = Symbol('BTCPAY_CLIENT');
 export const BTCPAY_CONFIG = Symbol('BTCPAY_CONFIG');
 
 export interface BtcpayConfig {
   baseUrl: string;
-  apiKey: string;
+  adminApiKey: string;
+  webhookUrl: string;
+  healthStoreId?: string;
+  healthApiKey?: string;
 }

--- a/apps/bff/src/health/health.controller.ts
+++ b/apps/bff/src/health/health.controller.ts
@@ -13,10 +13,16 @@ export class HealthController {
   @Get('readyz')
   async readyz() {
     try {
-      await this.btcpayService.listStores();
+      await this.btcpayService.healthProbe();
       return { status: 'ready' };
     } catch (error) {
       throw new InternalServerErrorException('BTCPay is not reachable', { cause: error as Error });
     }
+  }
+
+  @Get('internal/health/btcpay')
+  async btcpayHealth() {
+    await this.btcpayService.healthProbe();
+    return { status: 'ok' };
   }
 }

--- a/apps/bff/src/hooks/hooks.controller.ts
+++ b/apps/bff/src/hooks/hooks.controller.ts
@@ -1,0 +1,29 @@
+import { BadRequestException, Body, Controller, Headers, Post, Req } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+import type { Request } from 'express';
+import { HooksService } from './hooks.service';
+
+@Controller('hooks')
+export class HooksController {
+  constructor(private readonly hooksService: HooksService) {}
+
+  @SkipThrottle()
+  @Post('btcpay')
+  async handleBtcpayWebhook(
+    @Req() req: Request,
+    @Headers('btcpay-sig') signature: string | undefined,
+    @Headers('btcpay-delivery') deliveryHeader?: string,
+    @Headers('btcpay-deliveryid') legacyDeliveryHeader?: string,
+    @Body() payload: Record<string, unknown> = {}
+  ) {
+    const rawBody = (req as any).rawBody as Buffer | undefined;
+    const deliveryId = deliveryHeader || legacyDeliveryHeader;
+    if (!deliveryId) {
+      throw new BadRequestException('Missing delivery identifier');
+    }
+
+    await this.hooksService.handleWebhook(String(deliveryId), signature ?? '', rawBody ?? Buffer.alloc(0), payload);
+
+    return { status: 'accepted' };
+  }
+}

--- a/apps/bff/src/hooks/hooks.module.ts
+++ b/apps/bff/src/hooks/hooks.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HooksController } from './hooks.controller';
+import { HooksService } from './hooks.service';
+import { StoreEntity } from '../tenants/entities/store.entity';
+import { SecurityModule } from '../security/security.module';
+import { TenantsModule } from '../tenants/tenants.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([StoreEntity]), SecurityModule, TenantsModule],
+  controllers: [HooksController],
+  providers: [HooksService]
+})
+export class HooksModule {}

--- a/apps/bff/src/hooks/hooks.service.ts
+++ b/apps/bff/src/hooks/hooks.service.ts
@@ -1,0 +1,73 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { createHmac, timingSafeEqual } from 'crypto';
+import { StoreEntity } from '../tenants/entities/store.entity';
+import { EnvelopeEncryptionService } from '../security/envelope-encryption.service';
+import { TenantsService } from '../tenants/tenants.service';
+
+interface WebhookPayload {
+  storeId?: string;
+  invoiceId?: string;
+  [key: string]: unknown;
+}
+
+@Injectable()
+export class HooksService {
+  constructor(
+    @InjectRepository(StoreEntity)
+    private readonly storesRepository: Repository<StoreEntity>,
+    private readonly encryptionService: EnvelopeEncryptionService,
+    private readonly tenantsService: TenantsService
+  ) {}
+
+  async handleWebhook(deliveryId: string, signature: string, rawBody: Buffer, payload: WebhookPayload) {
+    if (!signature) {
+      throw new UnauthorizedException('Missing BTCPay signature');
+    }
+    if (!rawBody || rawBody.length === 0) {
+      throw new UnauthorizedException('Missing webhook payload');
+    }
+    if (!payload.storeId) {
+      throw new UnauthorizedException('Missing store identifier');
+    }
+
+    const store = await this.storesRepository.findOne({ where: { btcpayStoreId: payload.storeId } });
+    if (!store) {
+      await this.tenantsService.registerWebhookDelivery(null, deliveryId, payload.invoiceId ?? null);
+      return;
+    }
+
+    this.verifySignature(store, signature, rawBody);
+
+    const processed = await this.tenantsService.registerWebhookDelivery(store.tenantId, deliveryId, payload.invoiceId ?? null);
+    if (!processed) {
+      return;
+    }
+
+    // Additional domain-specific processing (e.g., invoice sync) would occur here.
+  }
+
+  private verifySignature(store: StoreEntity, signature: string, rawBody: Buffer) {
+    if (!signature) {
+      throw new UnauthorizedException('Missing BTCPay signature');
+    }
+
+    const secret = this.encryptionService.decrypt(store.webhookSecretCiphertext, store.webhookSecretDekWrapped);
+    try {
+      const hmac = createHmac('sha256', Buffer.from(secret, 'utf8')).update(rawBody).digest('hex');
+      const expected = Buffer.from(`sha256=${hmac}`, 'utf8');
+      const provided = Buffer.from(signature, 'utf8');
+      if (expected.length !== provided.length || !timingSafeEqual(expected, provided)) {
+        throw new UnauthorizedException('Invalid BTCPay signature');
+      }
+    } finally {
+      this.clearBuffer(secret);
+    }
+  }
+
+  private clearBuffer(value: string) {
+    const buf = Buffer.from(value, 'utf8');
+    buf.fill(0);
+  }
+}

--- a/apps/bff/src/main.ts
+++ b/apps/bff/src/main.ts
@@ -7,6 +7,7 @@ import helmet from 'helmet';
 import cookieParser from 'cookie-parser';
 import { Logger } from 'nestjs-pino';
 import { AppModule } from './app.module';
+import { json } from 'express';
 
 function parseTrustProxy(v?: string): any {
   if (v === undefined) {
@@ -34,8 +35,6 @@ async function bootstrap() {
   app.use(helmet());
   app.use(cookieParser());
 
-  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true }));
-
   const frontendOrigin = configService.get<string>('FRONTEND_ORIGIN');
   const corsOrigins = frontendOrigin ? [frontendOrigin] : [];
   app.enableCors({
@@ -53,9 +52,19 @@ async function bootstrap() {
 
   if (type === 'express' && typeof (instance as any).set === 'function') {
     (instance as any).set('trust proxy', trustProxyValue);
+    instance.use(
+      ['/hooks/btcpay', '/api/hooks/btcpay'],
+      json({
+        verify: (req: any, _res, buf: Buffer) => {
+          req.rawBody = Buffer.from(buf);
+        }
+      })
+    );
   } else if (type === 'fastify') {
     (instance as any).trustProxy = trustProxyValue;
   }
+
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true }));
 
   app.setGlobalPrefix('api', {
     exclude: [

--- a/apps/bff/src/migrations/1727800000000-CreateTenantSchema.ts
+++ b/apps/bff/src/migrations/1727800000000-CreateTenantSchema.ts
@@ -1,0 +1,127 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class CreateTenantSchema1727800000000 implements MigrationInterface {
+  name = 'CreateTenantSchema1727800000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'tenants',
+        columns: [
+          { name: 'id', type: 'uuid', isPrimary: true },
+          { name: 'email', type: 'varchar', isUnique: true },
+          { name: 'name', type: 'varchar' },
+          { name: 'created_at', type: 'timestamp with time zone', default: 'now()' },
+          { name: 'updated_at', type: 'timestamp with time zone', default: 'now()' }
+        ]
+      })
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'stores',
+        columns: [
+          { name: 'id', type: 'uuid', isPrimary: true },
+          { name: 'tenant_id', type: 'uuid' },
+          { name: 'btcpay_host', type: 'varchar' },
+          { name: 'btcpay_store_id', type: 'varchar', isUnique: true },
+          { name: 'api_key_ciphertext', type: 'text' },
+          { name: 'api_key_dek_wrapped', type: 'text' },
+          { name: 'webhook_id', type: 'varchar' },
+          { name: 'webhook_secret_ciphertext', type: 'text' },
+          { name: 'webhook_secret_dek_wrapped', type: 'text' },
+          { name: 'wallet_setup_status', type: 'varchar', default: "'pending'" },
+          { name: 'created_at', type: 'timestamp with time zone', default: 'now()' },
+          { name: 'updated_at', type: 'timestamp with time zone', default: 'now()' }
+        ]
+      })
+    );
+
+    await queryRunner.createForeignKey(
+      'stores',
+      new TableForeignKey({
+        columnNames: ['tenant_id'],
+        referencedTableName: 'tenants',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE'
+      })
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'audit_logs',
+        columns: [
+          { name: 'id', type: 'uuid', isPrimary: true },
+          { name: 'tenant_id', type: 'uuid' },
+          { name: 'actor_id', type: 'varchar', isNullable: true },
+          { name: 'action', type: 'varchar' },
+          { name: 'resource', type: 'varchar' },
+          { name: 'result', type: 'varchar' },
+          { name: 'ip', type: 'varchar', isNullable: true },
+          { name: 'ts', type: 'timestamp with time zone', default: 'now()' }
+        ]
+      })
+    );
+
+    await queryRunner.createForeignKey(
+      'audit_logs',
+      new TableForeignKey({
+        columnNames: ['tenant_id'],
+        referencedTableName: 'tenants',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE'
+      })
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'idempotency_keys',
+        columns: [
+          { name: 'key', type: 'varchar', isPrimary: true },
+          { name: 'tenant_id', type: 'uuid', isNullable: true },
+          { name: 'source', type: 'varchar' },
+          { name: 'resource_id', type: 'varchar', isNullable: true },
+          { name: 'ts', type: 'timestamp with time zone', default: 'now()' }
+        ]
+      })
+    );
+
+    await queryRunner.createForeignKey(
+      'idempotency_keys',
+      new TableForeignKey({
+        columnNames: ['tenant_id'],
+        referencedTableName: 'tenants',
+        referencedColumnNames: ['id'],
+        onDelete: 'SET NULL'
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const idempotencyForeignKeys = await queryRunner.getTable('idempotency_keys');
+    if (idempotencyForeignKeys) {
+      for (const fk of idempotencyForeignKeys.foreignKeys) {
+        await queryRunner.dropForeignKey('idempotency_keys', fk);
+      }
+    }
+    await queryRunner.dropTable('idempotency_keys');
+
+    const auditTable = await queryRunner.getTable('audit_logs');
+    if (auditTable) {
+      for (const fk of auditTable.foreignKeys) {
+        await queryRunner.dropForeignKey('audit_logs', fk);
+      }
+    }
+    await queryRunner.dropTable('audit_logs');
+
+    const storesTable = await queryRunner.getTable('stores');
+    if (storesTable) {
+      for (const fk of storesTable.foreignKeys) {
+        await queryRunner.dropForeignKey('stores', fk);
+      }
+    }
+    await queryRunner.dropTable('stores');
+
+    await queryRunner.dropTable('tenants');
+  }
+}

--- a/apps/bff/src/security/envelope-encryption.service.ts
+++ b/apps/bff/src/security/envelope-encryption.service.ts
@@ -1,0 +1,126 @@
+import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+interface AuthenticatedPayload {
+  iv: string;
+  ciphertext: string;
+  authTag: string;
+}
+
+export interface EncryptResult {
+  ciphertext: string;
+  dekWrapped: string;
+}
+
+@Injectable()
+export class EnvelopeEncryptionService {
+  private readonly logger = new Logger(EnvelopeEncryptionService.name, { timestamp: false });
+  private readonly masterKey: Buffer;
+
+  constructor(configService: ConfigService) {
+    const masterKeyB64 = configService.get<string>('BTCPAY_MASTER_KEY');
+    if (!masterKeyB64) {
+      throw new InternalServerErrorException('BTCPAY_MASTER_KEY is not configured');
+    }
+    const decoded = Buffer.from(masterKeyB64, 'base64');
+    if (decoded.length !== 32) {
+      decoded.fill(0);
+      throw new InternalServerErrorException('BTCPAY_MASTER_KEY must be a 256-bit base64 value');
+    }
+    this.masterKey = decoded;
+  }
+
+  encrypt(plaintext: string, dekWrapped?: string): EncryptResult {
+    const plaintextBuffer = Buffer.from(plaintext, 'utf8');
+    try {
+      const dek = dekWrapped ? this.unwrapDek(dekWrapped) : randomBytes(32);
+      const { payload, authTag } = this.encryptWithDek(plaintextBuffer, dek);
+      const wrappedDek = dekWrapped ?? this.wrapDek(dek);
+      dek.fill(0);
+      return { ciphertext: JSON.stringify({ ...payload, authTag }), dekWrapped: wrappedDek };
+    } finally {
+      plaintextBuffer.fill(0);
+    }
+  }
+
+  decrypt(ciphertext: string, dekWrapped: string): string {
+    const dek = this.unwrapDek(dekWrapped);
+    try {
+      const payload = this.parsePayload(ciphertext);
+      const plaintextBuffer = this.decryptWithDek(payload, dek);
+      try {
+        return plaintextBuffer.toString('utf8');
+      } finally {
+        plaintextBuffer.fill(0);
+      }
+    } finally {
+      dek.fill(0);
+    }
+  }
+
+  rewrapDek(dekWrapped: string): string {
+    const dek = this.unwrapDek(dekWrapped);
+    try {
+      return this.wrapDek(dek);
+    } finally {
+      dek.fill(0);
+    }
+  }
+
+  private encryptWithDek(
+    plaintext: Buffer,
+    dek: Buffer
+  ): { payload: Omit<AuthenticatedPayload, 'authTag'>; authTag: string } {
+    const iv = randomBytes(12);
+    const cipher = createCipheriv('aes-256-gcm', dek, iv);
+    const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+    return {
+      payload: {
+        iv: iv.toString('base64'),
+        ciphertext: ciphertext.toString('base64')
+      },
+      authTag: authTag.toString('base64')
+    };
+  }
+
+  private decryptWithDek(payload: AuthenticatedPayload, dek: Buffer): Buffer {
+    const decipher = createDecipheriv('aes-256-gcm', dek, Buffer.from(payload.iv, 'base64'));
+    decipher.setAuthTag(Buffer.from(payload.authTag, 'base64'));
+    return Buffer.concat([decipher.update(Buffer.from(payload.ciphertext, 'base64')), decipher.final()]);
+  }
+
+  private wrapDek(dek: Buffer): string {
+    const iv = randomBytes(12);
+    const cipher = createCipheriv('aes-256-gcm', this.masterKey, iv);
+    const ciphertext = Buffer.concat([cipher.update(dek), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+    const wrappedPayload: AuthenticatedPayload = {
+      iv: iv.toString('base64'),
+      ciphertext: ciphertext.toString('base64'),
+      authTag: authTag.toString('base64')
+    };
+    return JSON.stringify(wrappedPayload);
+  }
+
+  private unwrapDek(wrapped: string): Buffer {
+    const payload = this.parsePayload(wrapped);
+    const decipher = createDecipheriv('aes-256-gcm', this.masterKey, Buffer.from(payload.iv, 'base64'));
+    decipher.setAuthTag(Buffer.from(payload.authTag, 'base64'));
+    return Buffer.concat([decipher.update(Buffer.from(payload.ciphertext, 'base64')), decipher.final()]);
+  }
+
+  private parsePayload(raw: string): AuthenticatedPayload {
+    try {
+      const parsed = JSON.parse(raw) as AuthenticatedPayload;
+      if (!parsed.iv || !parsed.ciphertext || !parsed.authTag) {
+        throw new Error('Missing required fields');
+      }
+      return parsed;
+    } catch (error) {
+      this.logger.error('Failed to parse encryption payload');
+      throw new InternalServerErrorException('Corrupted encryption payload', { cause: error as Error });
+    }
+  }
+}

--- a/apps/bff/src/security/security.module.ts
+++ b/apps/bff/src/security/security.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { EnvelopeEncryptionService } from './envelope-encryption.service';
+
+@Module({
+  providers: [EnvelopeEncryptionService],
+  exports: [EnvelopeEncryptionService]
+})
+export class SecurityModule {}

--- a/apps/bff/src/tenants/dto/create-invoice.dto.ts
+++ b/apps/bff/src/tenants/dto/create-invoice.dto.ts
@@ -1,0 +1,17 @@
+import { IsNotEmpty, IsNumber, IsObject, IsOptional, IsString, IsUUID } from 'class-validator';
+
+export class CreateTenantInvoiceDto {
+  @IsUUID()
+  storeId!: string;
+
+  @IsNumber()
+  amount!: number;
+
+  @IsString()
+  @IsNotEmpty()
+  currency!: string;
+
+  @IsObject()
+  @IsOptional()
+  metadata?: Record<string, unknown>;
+}

--- a/apps/bff/src/tenants/dto/create-store.dto.ts
+++ b/apps/bff/src/tenants/dto/create-store.dto.ts
@@ -1,0 +1,15 @@
+import { IsBoolean, IsNotEmpty, IsOptional, IsString, IsUrl } from 'class-validator';
+
+export class CreateStoreDto {
+  @IsString()
+  @IsNotEmpty()
+  storeName!: string;
+
+  @IsUrl({ require_tld: false })
+  @IsOptional()
+  btcpayHost?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  includePullPayments?: boolean;
+}

--- a/apps/bff/src/tenants/dto/create-tenant.dto.ts
+++ b/apps/bff/src/tenants/dto/create-tenant.dto.ts
@@ -1,0 +1,22 @@
+import { IsBoolean, IsEmail, IsNotEmpty, IsOptional, IsString, IsUrl } from 'class-validator';
+
+export class CreateTenantDto {
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @IsUrl({ require_tld: false })
+  @IsOptional()
+  btcpayHost?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  storeName!: string;
+
+  @IsBoolean()
+  @IsOptional()
+  includePullPayments?: boolean;
+}

--- a/apps/bff/src/tenants/dto/rotate-api-key.dto.ts
+++ b/apps/bff/src/tenants/dto/rotate-api-key.dto.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from 'class-validator';
+
+export class RotateApiKeyQueryDto {
+  @IsUUID()
+  storeId!: string;
+}

--- a/apps/bff/src/tenants/entities/audit-log.entity.ts
+++ b/apps/bff/src/tenants/entities/audit-log.entity.ts
@@ -1,0 +1,33 @@
+import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { TenantEntity } from './tenant.entity';
+
+@Entity({ name: 'audit_logs' })
+export class AuditLogEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => TenantEntity, (tenant) => tenant.auditLogs, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'tenant_id' })
+  tenant!: TenantEntity;
+
+  @Column({ name: 'tenant_id' })
+  tenantId!: string;
+
+  @Column({ name: 'actor_id', nullable: true, type: 'varchar' })
+  actorId: string | null = null;
+
+  @Column()
+  action!: string;
+
+  @Column()
+  resource!: string;
+
+  @Column()
+  result!: string;
+
+  @Column({ nullable: true, type: 'varchar' })
+  ip!: string | null;
+
+  @CreateDateColumn({ name: 'ts' })
+  timestamp!: Date;
+}

--- a/apps/bff/src/tenants/entities/idempotency-key.entity.ts
+++ b/apps/bff/src/tenants/entities/idempotency-key.entity.ts
@@ -1,0 +1,19 @@
+import { Column, CreateDateColumn, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity({ name: 'idempotency_keys' })
+export class IdempotencyKeyEntity {
+  @PrimaryColumn()
+  key!: string;
+
+  @Column({ name: 'tenant_id', nullable: true, type: 'varchar' })
+  tenantId!: string | null;
+
+  @Column()
+  source!: string;
+
+  @Column({ name: 'resource_id', nullable: true, type: 'varchar' })
+  resourceId!: string | null;
+
+  @CreateDateColumn({ name: 'ts' })
+  timestamp!: Date;
+}

--- a/apps/bff/src/tenants/entities/store.entity.ts
+++ b/apps/bff/src/tenants/entities/store.entity.ts
@@ -1,0 +1,53 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from 'typeorm';
+import { TenantEntity } from './tenant.entity';
+
+@Entity({ name: 'stores' })
+export class StoreEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => TenantEntity, (tenant) => tenant.stores, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'tenant_id' })
+  tenant!: TenantEntity;
+
+  @Column({ name: 'tenant_id' })
+  tenantId!: string;
+
+  @Column({ name: 'btcpay_host' })
+  btcpayHost!: string;
+
+  @Column({ name: 'btcpay_store_id' })
+  btcpayStoreId!: string;
+
+  @Column({ name: 'api_key_ciphertext', type: 'text' })
+  apiKeyCiphertext!: string;
+
+  @Column({ name: 'api_key_dek_wrapped', type: 'text' })
+  apiKeyDekWrapped!: string;
+
+  @Column({ name: 'webhook_id' })
+  webhookId!: string;
+
+  @Column({ name: 'webhook_secret_ciphertext', type: 'text' })
+  webhookSecretCiphertext!: string;
+
+  @Column({ name: 'webhook_secret_dek_wrapped', type: 'text' })
+  webhookSecretDekWrapped!: string;
+
+  @Column({ name: 'wallet_setup_status', default: 'pending' })
+  walletSetupStatus!: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+}

--- a/apps/bff/src/tenants/entities/tenant.entity.ts
+++ b/apps/bff/src/tenants/entities/tenant.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from 'typeorm';
+import { StoreEntity } from './store.entity';
+import { AuditLogEntity } from './audit-log.entity';
+
+@Entity({ name: 'tenants' })
+export class TenantEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ unique: true })
+  email!: string;
+
+  @Column()
+  name!: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+
+  @OneToMany(() => StoreEntity, (store) => store.tenant)
+  stores!: StoreEntity[];
+
+  @OneToMany(() => AuditLogEntity, (log) => log.tenant)
+  auditLogs!: AuditLogEntity[];
+}

--- a/apps/bff/src/tenants/tenants.controller.ts
+++ b/apps/bff/src/tenants/tenants.controller.ts
@@ -1,0 +1,68 @@
+import {
+  Body,
+  Controller,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+  Req
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { TenantsService } from './tenants.service';
+import { CreateTenantDto } from './dto/create-tenant.dto';
+import { CreateStoreDto } from './dto/create-store.dto';
+import { CreateTenantInvoiceDto } from './dto/create-invoice.dto';
+import { RotateApiKeyQueryDto } from './dto/rotate-api-key.dto';
+
+@Controller('tenants')
+export class TenantsController {
+  constructor(private readonly tenantsService: TenantsService) {}
+
+  @Post()
+  createTenant(@Body() dto: CreateTenantDto, @Req() req: Request) {
+    const actorId = this.resolveActorId(req);
+    const ip = this.extractIp(req);
+    return this.tenantsService.createTenant(dto, actorId, ip);
+  }
+
+  @Post(':tenantId/stores')
+  createStore(
+    @Param('tenantId', ParseUUIDPipe) tenantId: string,
+    @Body() dto: CreateStoreDto,
+    @Req() req: Request
+  ) {
+    const actorId = this.resolveActorId(req);
+    const ip = this.extractIp(req);
+    return this.tenantsService.createAdditionalStore(tenantId, dto, actorId, ip);
+  }
+
+  @Post(':tenantId/invoices')
+  createInvoice(
+    @Param('tenantId', ParseUUIDPipe) tenantId: string,
+    @Body() dto: CreateTenantInvoiceDto
+  ) {
+    return this.tenantsService.createInvoice(tenantId, dto);
+  }
+
+  @Post(':tenantId/apikey/rotate')
+  rotateApiKey(
+    @Param('tenantId', ParseUUIDPipe) tenantId: string,
+    @Query() query: RotateApiKeyQueryDto,
+    @Req() req: Request
+  ) {
+    const actorId = this.resolveActorId(req);
+    return this.tenantsService.rotateStoreApiKey(tenantId, query.storeId, actorId);
+  }
+
+  private resolveActorId(req: Request): string | null {
+    const user = (req as any).user;
+    if (user && typeof user.id === 'string') {
+      return user.id;
+    }
+    return null;
+  }
+
+  private extractIp(req: Request): string | null {
+    return req.ip ?? null;
+  }
+}

--- a/apps/bff/src/tenants/tenants.module.ts
+++ b/apps/bff/src/tenants/tenants.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TenantEntity } from './entities/tenant.entity';
+import { StoreEntity } from './entities/store.entity';
+import { AuditLogEntity } from './entities/audit-log.entity';
+import { IdempotencyKeyEntity } from './entities/idempotency-key.entity';
+import { TenantsService } from './tenants.service';
+import { TenantsController } from './tenants.controller';
+import { SecurityModule } from '../security/security.module';
+import { BtcpayModule } from '../btcpay/btcpay.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([TenantEntity, StoreEntity, AuditLogEntity, IdempotencyKeyEntity]),
+    SecurityModule,
+    BtcpayModule
+  ],
+  controllers: [TenantsController],
+  providers: [TenantsService],
+  exports: [TenantsService]
+})
+export class TenantsModule {}

--- a/apps/bff/src/tenants/tenants.service.ts
+++ b/apps/bff/src/tenants/tenants.service.ts
@@ -1,0 +1,300 @@
+import { Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { TenantEntity } from './entities/tenant.entity';
+import { StoreEntity } from './entities/store.entity';
+import { AuditLogEntity } from './entities/audit-log.entity';
+import { IdempotencyKeyEntity } from './entities/idempotency-key.entity';
+import { CreateTenantDto } from './dto/create-tenant.dto';
+import { CreateStoreDto } from './dto/create-store.dto';
+import { EnvelopeEncryptionService } from '../security/envelope-encryption.service';
+import { BtcpayService } from '../btcpay/btcpay.service';
+import { CreateTenantInvoiceDto } from './dto/create-invoice.dto';
+
+interface CreateTenantResult {
+  tenantId: string;
+  storeId: string;
+  btcpayStoreId: string;
+}
+
+@Injectable()
+export class TenantsService {
+  private readonly logger = new Logger(TenantsService.name, { timestamp: false });
+  private static readonly TEMPORARY_STORE_PERMISSION = ['btcpay.store.canmodifystoresettings'];
+
+  constructor(
+    @InjectRepository(TenantEntity)
+    private readonly tenantsRepository: Repository<TenantEntity>,
+    @InjectRepository(StoreEntity)
+    private readonly storesRepository: Repository<StoreEntity>,
+    @InjectRepository(AuditLogEntity)
+    private readonly auditRepository: Repository<AuditLogEntity>,
+    @InjectRepository(IdempotencyKeyEntity)
+    private readonly idempotencyRepository: Repository<IdempotencyKeyEntity>,
+    private readonly encryptionService: EnvelopeEncryptionService,
+    private readonly btcpayService: BtcpayService,
+    private readonly dataSource: DataSource
+  ) {}
+
+  async createTenant(dto: CreateTenantDto, actorId: string | null, ip: string | null): Promise<CreateTenantResult> {
+    const baseUrl = this.btcpayService.resolveBaseUrl(dto.btcpayHost);
+    await this.btcpayService.createUser(baseUrl, {
+      email: dto.email,
+      name: dto.name,
+      sendInvitationEmail: true
+    });
+
+    const temporaryKey = await this.btcpayService.createUserApiKeyUnscoped(
+      baseUrl,
+      dto.email,
+      TenantsService.TEMPORARY_STORE_PERMISSION,
+      'Temp store setup'
+    );
+
+    let store: { id: string };
+    try {
+      store = await this.btcpayService.createStoreWithUserToken(baseUrl, temporaryKey.apiKey, {
+        name: dto.storeName
+      });
+    } catch (error) {
+      await this.safeDeleteTemporaryKey(baseUrl, temporaryKey.apiKey);
+      this.clearBuffer(temporaryKey.apiKey);
+      throw error;
+    }
+
+    await this.safeDeleteTemporaryKey(baseUrl, temporaryKey.apiKey);
+    this.clearBuffer(temporaryKey.apiKey);
+
+    try {
+      const apiKey = await this.btcpayService.createUserApiKey(baseUrl, dto.email, store.id, dto.includePullPayments ?? false);
+      const webhook = await this.btcpayService.registerWebhook(baseUrl, apiKey.apiKey, store.id);
+      if (!webhook.secret) {
+        throw new InternalServerErrorException('BTCPay webhook secret was not returned');
+      }
+
+      const encryptedApiKey = this.encryptionService.encrypt(apiKey.apiKey);
+      const encryptedWebhook = this.encryptionService.encrypt(webhook.secret, encryptedApiKey.dekWrapped);
+
+      this.clearBuffer(apiKey.apiKey);
+      this.clearBuffer(webhook.secret);
+
+      return this.dataSource.transaction(async (manager) => {
+        const tenant = manager.getRepository(TenantEntity).create({
+          email: dto.email,
+          name: dto.name
+        });
+        await manager.getRepository(TenantEntity).save(tenant);
+
+        const storeEntity = manager.getRepository(StoreEntity).create({
+          tenantId: tenant.id,
+          btcpayHost: baseUrl,
+          btcpayStoreId: store.id,
+          apiKeyCiphertext: encryptedApiKey.ciphertext,
+          apiKeyDekWrapped: encryptedApiKey.dekWrapped,
+          webhookId: webhook.id,
+          webhookSecretCiphertext: encryptedWebhook.ciphertext,
+          webhookSecretDekWrapped: encryptedWebhook.dekWrapped,
+          walletSetupStatus: 'pending'
+        });
+        await manager.getRepository(StoreEntity).save(storeEntity);
+
+        await manager.getRepository(AuditLogEntity).save({
+          tenantId: tenant.id,
+          actorId,
+          action: 'tenant.created',
+          resource: storeEntity.id,
+          result: 'success',
+          ip
+        });
+
+        return {
+          tenantId: tenant.id,
+          storeId: storeEntity.id,
+          btcpayStoreId: store.id
+        } satisfies CreateTenantResult;
+      });
+    } catch (error) {
+      this.logger.error('Failed to onboard tenant', (error as Error).message);
+      throw error;
+    }
+  }
+
+  async createAdditionalStore(tenantId: string, dto: CreateStoreDto, actorId: string | null, ip: string | null) {
+    const tenant = await this.tenantsRepository.findOne({ where: { id: tenantId } });
+    if (!tenant) {
+      throw new NotFoundException('Tenant not found');
+    }
+    const primaryStore = await this.storesRepository.findOne({ where: { tenantId }, order: { createdAt: 'ASC' } });
+    const baseUrl = this.btcpayService.resolveBaseUrl(dto.btcpayHost ?? primaryStore?.btcpayHost);
+
+    const temporaryKey = await this.btcpayService.createUserApiKeyUnscoped(
+      baseUrl,
+      tenant.email,
+      TenantsService.TEMPORARY_STORE_PERMISSION,
+      'Temp store setup'
+    );
+
+    let store: { id: string };
+    try {
+      store = await this.btcpayService.createStoreWithUserToken(baseUrl, temporaryKey.apiKey, { name: dto.storeName });
+    } catch (error) {
+      await this.safeDeleteTemporaryKey(baseUrl, temporaryKey.apiKey);
+      this.clearBuffer(temporaryKey.apiKey);
+      throw error;
+    }
+
+    await this.safeDeleteTemporaryKey(baseUrl, temporaryKey.apiKey);
+    this.clearBuffer(temporaryKey.apiKey);
+
+    const apiKey = await this.btcpayService.createUserApiKey(baseUrl, tenant.email, store.id, dto.includePullPayments ?? false);
+    const webhook = await this.btcpayService.registerWebhook(baseUrl, apiKey.apiKey, store.id);
+    if (!webhook.secret) {
+      throw new InternalServerErrorException('BTCPay webhook secret was not returned');
+    }
+
+    const encryptedApiKey = this.encryptionService.encrypt(apiKey.apiKey);
+    const encryptedWebhook = this.encryptionService.encrypt(webhook.secret, encryptedApiKey.dekWrapped);
+
+    this.clearBuffer(apiKey.apiKey);
+    this.clearBuffer(webhook.secret);
+
+    return this.dataSource.transaction(async (manager) => {
+      const storeEntity = manager.getRepository(StoreEntity).create({
+        tenantId,
+        btcpayHost: baseUrl,
+        btcpayStoreId: store.id,
+        apiKeyCiphertext: encryptedApiKey.ciphertext,
+        apiKeyDekWrapped: encryptedApiKey.dekWrapped,
+        webhookId: webhook.id,
+        webhookSecretCiphertext: encryptedWebhook.ciphertext,
+        webhookSecretDekWrapped: encryptedWebhook.dekWrapped,
+        walletSetupStatus: 'pending'
+      });
+      await manager.getRepository(StoreEntity).save(storeEntity);
+
+      await manager.getRepository(AuditLogEntity).save({
+        tenantId,
+        actorId,
+        action: 'tenant.store.created',
+        resource: storeEntity.id,
+        result: 'success',
+        ip
+      });
+
+      return {
+        storeId: storeEntity.id,
+        btcpayStoreId: store.id
+      };
+    });
+  }
+
+  async createInvoice(tenantId: string, dto: CreateTenantInvoiceDto) {
+    const store = await this.storesRepository.findOne({ where: { id: dto.storeId, tenantId } });
+    if (!store) {
+      throw new NotFoundException('Store not found');
+    }
+
+    const apiKey = this.encryptionService.decrypt(store.apiKeyCiphertext, store.apiKeyDekWrapped);
+    try {
+      const invoice = await this.btcpayService.createInvoice(store.btcpayHost, apiKey, store.btcpayStoreId, {
+        amount: dto.amount,
+        currency: dto.currency,
+        metadata: dto.metadata ?? {}
+      });
+      return {
+        invoiceId: invoice.id,
+        checkoutLink: invoice.checkoutLink,
+        status: invoice.status
+      };
+    } finally {
+      this.clearBuffer(apiKey);
+    }
+  }
+
+  async rotateStoreApiKey(tenantId: string, storeId: string, actorId: string | null) {
+    const store = await this.storesRepository.findOne({ where: { id: storeId, tenantId } });
+    if (!store) {
+      throw new NotFoundException('Store not found');
+    }
+
+    const tenant = await this.tenantsRepository.findOne({ where: { id: tenantId } });
+    if (!tenant) {
+      throw new NotFoundException('Tenant not found');
+    }
+
+    const oldApiKey = this.encryptionService.decrypt(store.apiKeyCiphertext, store.apiKeyDekWrapped);
+    const webhookSecret = this.encryptionService.decrypt(store.webhookSecretCiphertext, store.webhookSecretDekWrapped);
+
+    try {
+      const apiKey = await this.btcpayService.createUserApiKey(store.btcpayHost, tenant.email, store.btcpayStoreId, false);
+      const encryptedApiKey = this.encryptionService.encrypt(apiKey.apiKey);
+      const encryptedWebhook = this.encryptionService.encrypt(webhookSecret, encryptedApiKey.dekWrapped);
+
+      await this.storesRepository.update(store.id, {
+        apiKeyCiphertext: encryptedApiKey.ciphertext,
+        apiKeyDekWrapped: encryptedApiKey.dekWrapped,
+        webhookSecretCiphertext: encryptedWebhook.ciphertext,
+        webhookSecretDekWrapped: encryptedWebhook.dekWrapped
+      });
+
+      await this.auditRepository.save({
+        tenantId,
+        actorId,
+        action: 'tenant.store.apiKeyRotated',
+        resource: store.id,
+        result: 'success',
+        ip: null
+      });
+
+      await this.btcpayService.deleteApiKey(store.btcpayHost, oldApiKey);
+
+      const lastFour = apiKey.apiKey.slice(-4);
+      this.clearBuffer(apiKey.apiKey);
+      return { lastFour };
+    } finally {
+      this.clearBuffer(oldApiKey);
+      this.clearBuffer(webhookSecret);
+    }
+  }
+
+  async registerWebhookDelivery(tenantId: string | null, deliveryId: string, resourceId: string | null) {
+    const exists = await this.idempotencyRepository.findOne({ where: { key: deliveryId } });
+    if (exists) {
+      return false;
+    }
+    try {
+      await this.idempotencyRepository.insert({
+        key: deliveryId,
+        tenantId,
+        source: 'btcpay_webhook',
+        resourceId
+      });
+      return true;
+    } catch (error) {
+      if ((error as { code?: string }).code === '23505') {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  private clearBuffer(value: string | null | undefined) {
+    if (!value) {
+      return;
+    }
+    try {
+      const buf = Buffer.from(value);
+      buf.fill(0);
+    } catch (error) {
+      this.logger.warn('Failed to clear buffer', error as Error);
+    }
+  }
+
+  private async safeDeleteTemporaryKey(baseUrl: string, apiKey: string) {
+    try {
+      await this.btcpayService.deleteApiKey(baseUrl, apiKey);
+    } catch (error) {
+      this.logger.warn('Failed to revoke temporary BTCPay API key', error as Error);
+    }
+  }
+}

--- a/apps/bff/test/hooks.e2e-spec.ts
+++ b/apps/bff/test/hooks.e2e-spec.ts
@@ -1,0 +1,53 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import request from 'supertest';
+import { json } from 'express';
+import { AppModule } from '../src/app.module';
+
+describe('BTCPay webhook CSRF bypass (e2e)', () => {
+  let app: INestApplication;
+  let server: any;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule]
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true })
+    );
+
+    const httpAdapter = app.getHttpAdapter();
+    const instance = httpAdapter.getInstance();
+    instance.use(
+      ['/hooks/btcpay', '/api/hooks/btcpay'],
+      json({
+        verify: (req: any, _res, buf: Buffer) => {
+          req.rawBody = Buffer.from(buf);
+        }
+      })
+    );
+
+    app.setGlobalPrefix('api');
+    await app.init();
+    server = app.getHttpServer();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('accepts webhook requests that include BTCPAY-SIG without CSRF tokens', async () => {
+    const response = await request(server)
+      .post('/api/hooks/btcpay')
+      .set('BTCPAY-SIG', 'sha256=test')
+      .set('BTCPAY-DELIVERY', 'delivery-test')
+      .send({ storeId: 'missing-store' });
+
+    expect(response.status).not.toBe(403);
+    expect(response.body).toEqual(expect.objectContaining({ status: 'accepted' }));
+  });
+});

--- a/apps/bff/test/hooks.service.spec.ts
+++ b/apps/bff/test/hooks.service.spec.ts
@@ -1,0 +1,51 @@
+import { createHmac } from 'crypto';
+import { HooksService } from '../src/hooks/hooks.service';
+import { StoreEntity } from '../src/tenants/entities/store.entity';
+
+describe('HooksService', () => {
+  const makeService = () => {
+    const store: Partial<StoreEntity> = {
+      tenantId: 'tenant-1',
+      webhookSecretCiphertext: 'cipher',
+      webhookSecretDekWrapped: 'dek',
+      btcpayStoreId: 'store-1'
+    };
+    const storeRepo = {
+      findOne: jest.fn().mockResolvedValue(store)
+    } as any;
+    const encryption = {
+      decrypt: jest.fn().mockReturnValue('secret-value')
+    } as any;
+    const tenants = {
+      registerWebhookDelivery: jest.fn().mockResolvedValue(true)
+    } as any;
+
+    const service = new HooksService(storeRepo, encryption, tenants);
+    return { service, storeRepo, encryption, tenants, store: store as StoreEntity };
+  };
+
+  it('accepts valid signatures', async () => {
+    const { service, tenants, encryption } = makeService();
+    const body = Buffer.from(JSON.stringify({ storeId: 'store-1', invoiceId: 'inv-1' }));
+    const signature = `sha256=${createHmac('sha256', 'secret-value').update(body).digest('hex')}`;
+
+    await service.handleWebhook('delivery-1', signature, body, {
+      storeId: 'store-1',
+      invoiceId: 'inv-1'
+    });
+
+    expect(encryption.decrypt).toHaveBeenCalled();
+    expect(tenants.registerWebhookDelivery).toHaveBeenCalledWith('tenant-1', 'delivery-1', 'inv-1');
+  });
+
+  it('rejects invalid signatures', async () => {
+    const { service } = makeService();
+    const body = Buffer.from(JSON.stringify({ storeId: 'store-1' }));
+
+    await expect(
+      service.handleWebhook('delivery-2', 'sha256=deadbeef', body, {
+        storeId: 'store-1'
+      })
+    ).rejects.toThrow('Invalid BTCPay signature');
+  });
+});

--- a/apps/bff/test/setup-env.ts
+++ b/apps/bff/test/setup-env.ts
@@ -5,4 +5,9 @@ process.env.JWT_ACCESS_TOKEN_SECRET = process.env.JWT_ACCESS_TOKEN_SECRET ?? 'te
 process.env.JWT_REFRESH_TOKEN_SECRET = process.env.JWT_REFRESH_TOKEN_SECRET ?? 'test-refresh-secret';
 process.env.FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN ?? 'http://localhost:3000';
 process.env.BTCPAY_URL = process.env.BTCPAY_URL ?? 'https://btcpay.local';
-process.env.BTCPAY_API_KEY = process.env.BTCPAY_API_KEY ?? 'test-api-key';
+process.env.BTCPAY_ADMIN_API_KEY = process.env.BTCPAY_ADMIN_API_KEY ?? 'test-admin-api-key';
+process.env.BTCPAY_MASTER_KEY =
+  process.env.BTCPAY_MASTER_KEY ?? Buffer.from('0123456789abcdef0123456789abcdef').toString('base64');
+process.env.BTCPAY_WEBHOOK_URL = process.env.BTCPAY_WEBHOOK_URL ?? 'https://api.local/hooks/btcpay';
+process.env.BTCPAY_HEALTH_STORE_ID = process.env.BTCPAY_HEALTH_STORE_ID ?? 'store-health';
+process.env.BTCPAY_HEALTH_API_KEY = process.env.BTCPAY_HEALTH_API_KEY ?? 'health-api-key';

--- a/apps/bff/test/tenants.service.spec.ts
+++ b/apps/bff/test/tenants.service.spec.ts
@@ -1,0 +1,200 @@
+import { DataSource } from 'typeorm';
+import { TenantsService } from '../src/tenants/tenants.service';
+import { TenantEntity } from '../src/tenants/entities/tenant.entity';
+import { StoreEntity } from '../src/tenants/entities/store.entity';
+import { AuditLogEntity } from '../src/tenants/entities/audit-log.entity';
+import { EnvelopeEncryptionService } from '../src/security/envelope-encryption.service';
+import { BtcpayService } from '../src/btcpay/btcpay.service';
+
+describe('TenantsService onboarding flows', () => {
+  function createService() {
+    const tenantsRepository = {
+      findOne: jest.fn()
+    } as unknown as jest.Mocked<any>;
+    const storesRepository = {
+      findOne: jest.fn()
+    } as unknown as jest.Mocked<any>;
+    const auditRepository = {} as unknown as jest.Mocked<any>;
+    const idempotencyRepository = {} as unknown as jest.Mocked<any>;
+
+    const encryptionService = {
+      encrypt: jest.fn()
+    } as unknown as jest.Mocked<EnvelopeEncryptionService>;
+
+    const btcpayService = {
+      resolveBaseUrl: jest.fn((host?: string) => host ?? 'https://btcpay.test'),
+      createUser: jest.fn().mockResolvedValue({ id: 'user-1', email: 'merchant@example.com' }),
+      createUserApiKeyUnscoped: jest.fn().mockResolvedValue({ apiKey: 'temp-key', permissions: ['btcpay.store.canmodifystoresettings'] }),
+      createStoreWithUserToken: jest.fn().mockResolvedValue({ id: 'btcpay-store-id' }),
+      deleteApiKey: jest.fn().mockResolvedValue(undefined),
+      createUserApiKey: jest.fn().mockResolvedValue({ apiKey: 'store-key', permissions: [] }),
+      registerWebhook: jest.fn().mockResolvedValue({ id: 'webhook-id', secret: 'webhook-secret' })
+    } as unknown as jest.Mocked<BtcpayService>;
+
+    const tenantRepoInTx = {
+      create: jest.fn((payload) => ({ id: 'tenant-entity-id', ...payload })),
+      save: jest.fn().mockImplementation(async (entity) => entity)
+    };
+    const storeRepoInTx = {
+      create: jest.fn((payload) => ({ id: 'store-entity-id', ...payload })),
+      save: jest.fn().mockImplementation(async (entity) => entity)
+    };
+    const auditRepoInTx = {
+      save: jest.fn().mockResolvedValue(undefined)
+    };
+
+    const manager = {
+      getRepository: jest.fn((entity) => {
+        if (entity === TenantEntity) return tenantRepoInTx;
+        if (entity === StoreEntity) return storeRepoInTx;
+        if (entity === AuditLogEntity) return auditRepoInTx;
+        throw new Error('Unexpected repository request');
+      })
+    };
+
+    const dataSource = {
+      transaction: jest.fn(async (callback: (manager: typeof manager) => Promise<any>) => callback(manager))
+    } as unknown as DataSource;
+
+    const service = new TenantsService(
+      tenantsRepository,
+      storesRepository,
+      auditRepository,
+      idempotencyRepository,
+      encryptionService,
+      btcpayService,
+      dataSource
+    );
+
+    return {
+      service,
+      tenantsRepository,
+      storesRepository,
+      encryptionService,
+      btcpayService,
+      dataSource,
+      tenantRepoInTx,
+      storeRepoInTx,
+      auditRepoInTx
+    };
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('creates tenants using temporary user keys and revokes them', async () => {
+    const {
+      service,
+      encryptionService,
+      btcpayService,
+      dataSource,
+      tenantRepoInTx,
+      storeRepoInTx,
+      auditRepoInTx
+    } = createService();
+
+    (encryptionService.encrypt as jest.Mock).mockReturnValueOnce({ ciphertext: 'api-cipher', dekWrapped: 'api-dek' });
+    (encryptionService.encrypt as jest.Mock).mockReturnValueOnce({ ciphertext: 'webhook-cipher', dekWrapped: 'webhook-dek' });
+
+    const result = await service.createTenant(
+      {
+        email: 'merchant@example.com',
+        name: 'Merchant',
+        storeName: 'Demo Store',
+        btcpayHost: 'https://btcpay.custom',
+        includePullPayments: false
+      },
+      'actor-1',
+      '127.0.0.1'
+    );
+
+    expect(btcpayService.createUser).toHaveBeenCalledWith('https://btcpay.custom', {
+      email: 'merchant@example.com',
+      name: 'Merchant',
+      sendInvitationEmail: true
+    });
+    expect(btcpayService.createUserApiKeyUnscoped).toHaveBeenCalledWith(
+      'https://btcpay.custom',
+      'merchant@example.com',
+      ['btcpay.store.canmodifystoresettings'],
+      'Temp store setup'
+    );
+    expect(btcpayService.createStoreWithUserToken).toHaveBeenCalledWith('https://btcpay.custom', 'temp-key', {
+      name: 'Demo Store'
+    });
+    expect(btcpayService.deleteApiKey).toHaveBeenCalledWith('https://btcpay.custom', 'temp-key');
+    expect(btcpayService.createUserApiKey).toHaveBeenCalledWith('https://btcpay.custom', 'merchant@example.com', 'btcpay-store-id', false);
+    expect(btcpayService.registerWebhook).toHaveBeenCalledWith('https://btcpay.custom', 'store-key', 'btcpay-store-id');
+
+    expect(encryptionService.encrypt).toHaveBeenNthCalledWith(1, 'store-key');
+    expect(encryptionService.encrypt).toHaveBeenNthCalledWith(2, 'webhook-secret', 'api-dek');
+
+    expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+    expect(tenantRepoInTx.create).toHaveBeenCalled();
+    expect(storeRepoInTx.create).toHaveBeenCalled();
+    expect(auditRepoInTx.save).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'tenant.created', actorId: 'actor-1' })
+    );
+
+    expect(result).toEqual({
+      tenantId: 'tenant-entity-id',
+      storeId: 'store-entity-id',
+      btcpayStoreId: 'btcpay-store-id'
+    });
+  });
+
+  it('creates additional stores using the temporary user key flow', async () => {
+    const {
+      service,
+      tenantsRepository,
+      storesRepository,
+      encryptionService,
+      btcpayService,
+      dataSource,
+      storeRepoInTx,
+      auditRepoInTx
+    } = createService();
+
+    tenantsRepository.findOne.mockResolvedValue({ id: 'tenant-entity-id', email: 'merchant@example.com' });
+    storesRepository.findOne.mockResolvedValue({ btcpayHost: 'https://btcpay.test' });
+
+    (encryptionService.encrypt as jest.Mock).mockReturnValueOnce({ ciphertext: 'api-cipher', dekWrapped: 'api-dek' });
+    (encryptionService.encrypt as jest.Mock).mockReturnValueOnce({ ciphertext: 'webhook-cipher', dekWrapped: 'webhook-dek' });
+
+    const result = await service.createAdditionalStore(
+      'tenant-entity-id',
+      {
+        storeName: 'Second Store',
+        includePullPayments: true
+      },
+      'actor-2',
+      '127.0.0.1'
+    );
+
+    expect(btcpayService.createUser).not.toHaveBeenCalled();
+    expect(btcpayService.createUserApiKeyUnscoped).toHaveBeenCalledWith(
+      'https://btcpay.test',
+      'merchant@example.com',
+      ['btcpay.store.canmodifystoresettings'],
+      'Temp store setup'
+    );
+    expect(btcpayService.createStoreWithUserToken).toHaveBeenCalledWith('https://btcpay.test', 'temp-key', {
+      name: 'Second Store'
+    });
+    expect(btcpayService.deleteApiKey).toHaveBeenCalledWith('https://btcpay.test', 'temp-key');
+    expect(btcpayService.createUserApiKey).toHaveBeenCalledWith('https://btcpay.test', 'merchant@example.com', 'btcpay-store-id', true);
+    expect(btcpayService.registerWebhook).toHaveBeenCalledWith('https://btcpay.test', 'store-key', 'btcpay-store-id');
+
+    expect(encryptionService.encrypt).toHaveBeenNthCalledWith(1, 'store-key');
+    expect(encryptionService.encrypt).toHaveBeenNthCalledWith(2, 'webhook-secret', 'api-dek');
+
+    expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+    expect(storeRepoInTx.create).toHaveBeenCalled();
+    expect(auditRepoInTx.save).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'tenant.store.created', actorId: 'actor-2' })
+    );
+
+    expect(result).toEqual({ storeId: 'store-entity-id', btcpayStoreId: 'btcpay-store-id' });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       argon2:
         specifier: ^0.41.1
         version: 0.41.1
+      axios:
+        specifier: ^1.7.7
+        version: 1.12.2
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1


### PR DESCRIPTION
## Summary
- rework tenant onboarding and additional store provisioning to issue and revoke temporary user-scoped API keys before creating store-scoped credentials and encrypted webhooks
- enhance BTCPay client error handling, add helpers for unscoped key issuance and store creation, and exempt BTCPay webhooks from CSRF when a signature is present
- document the narrowed admin key scope and add unit plus e2e coverage for the onboarding flow and webhook CSRF bypass
- ensure webhook middleware covers both /hooks/btcpay and /api/hooks/btcpay, require signatures before processing deliveries, and redact BTCPay headers while documenting the /api-prefixed webhook URL

## Testing
- pnpm --filter bff test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68da66f14a54832fa80005bfa495bca0