### PR TITLE
docs: document environment templates for docker deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,30 @@ PayPay is a monorepo housing the Next.js merchant portal, NestJS BFF, and a type
 - `infra/env` – Environment templates for local and production setups.
 - `docs/` – Architecture and privacy references.
 
+## Environment files you will edit
+
+We use two env files:
+
+1) `deploy/docker/.env` — read by Docker Compose for variable substitution (domains, proxy).
+   - Create from template:
+     ```bash
+     cp deploy/docker/.env.example deploy/docker/.env
+     ```
+   - Set: `PAYPAY_DOMAIN`, `PAYPAY_API_DOMAIN`, `CADDY_ADMIN_EMAIL`
+
+2) `infra/env/.env` — injected into containers as real environment (BFF/Frontend config, secrets).
+   - Create from template:
+     ```bash
+     cp infra/env/.env.example infra/env/.env
+     ```
+   - Set at least:
+     - `FRONTEND_ORIGIN`, `NEXT_PUBLIC_BFF_URL`
+     - `BTCPAY_URL`, `BTCPAY_ADMIN_API_KEY`
+     - `BTCPAY_MASTER_KEY` (base64 32 bytes; generate via `openssl rand -base64 32`)
+     - `BTCPAY_WEBHOOK_URL` (use `https://$PAYPAY_API_DOMAIN/api/hooks/btcpay`)
+     - `JWT_ACCESS_TOKEN_SECRET`, `JWT_REFRESH_TOKEN_SECRET`
+     - `POSTGRES_*`, `REDIS_*` (or leave defaults)
+
 ## Production (Docker-only)
 ### Prerequisites
 - A host with Docker Engine and the Docker Compose plugin installed.
@@ -17,23 +41,8 @@ PayPay is a monorepo housing the Next.js merchant portal, NestJS BFF, and a type
 - The ability to receive HTTPS traffic on port 443 (Caddy terminates TLS and renews certificates automatically).
 
 ### Configuration
-1. Copy the environment template and edit it for your deployment:
-   ```bash
-   cp infra/env/.env.example infra/env/.env
-   ```
-2. Open `infra/env/.env` and set the required values:
-   - `PAYPAY_DOMAIN` / `PAYPAY_API_DOMAIN` – public domains that end-users will visit.
-   - `CADDY_ADMIN_EMAIL` – email for ACME certificate management.
-  - `NEXT_PUBLIC_BFF_URL` – must be `https://<PAYPAY_API_DOMAIN>` so the frontend CSP allows calls to the BFF.
-  - `NEXT_PUBLIC_API_BASE` – defaults to `/api`; adjust only if the BFF is mounted elsewhere behind your proxy.
-  - `FRONTEND_ORIGIN` – must be `https://<PAYPAY_DOMAIN>` so the BFF CORS policy matches the UI.
-  - `BTCPAY_URL` – base URL of your BTCPay Server instance.
-  - `BTCPAY_ADMIN_API_KEY` – server-admin API key used for automated onboarding.
-  - `BTCPAY_MASTER_KEY` – base64-encoded 32-byte master key for envelope encryption.
-- `BTCPAY_WEBHOOK_URL` – public HTTPS endpoint for webhook deliveries (e.g. `https://$PAYPAY_API_DOMAIN/api/hooks/btcpay`).
-  - `BTCPAY_HEALTH_STORE_ID` / `BTCPAY_HEALTH_API_KEY` – optional credentials for the internal BTCPay health probe.
-   - `JWT_ACCESS_TOKEN_SECRET` and `JWT_REFRESH_TOKEN_SECRET` – secrets for issuing user tokens.
-   - Database/cache settings (`POSTGRES_*`, `REDIS_*`) – defaults work out of the box but can be overridden.
+1. Prepare `deploy/docker/.env` and `infra/env/.env` using the templates described above.
+2. Review `infra/env/.env` and ensure domains, BTCPay credentials, JWT secrets, and database/cache settings are correct for your deployment. `BTCPAY_WEBHOOK_URL` should point to the BFF webhook endpoint proxied by Caddy (default: `https://$PAYPAY_API_DOMAIN/api/hooks/btcpay`).
 3. From the server, build and start the stack (no Node.js or pnpm required on the host):
    ```bash
    cd deploy/docker
@@ -41,6 +50,12 @@ PayPay is a monorepo housing the Next.js merchant portal, NestJS BFF, and a type
    ```
 
 This command builds the frontend and BFF images inside their respective containers and launches five services: Postgres, Redis, the BFF, the frontend, and Caddy. Once running, HTTPS traffic to `https://$PAYPAY_DOMAIN` serves the Next.js UI and `https://$PAYPAY_API_DOMAIN/docs` proxies the BFF Swagger UI via Caddy.
+
+```bash
+# After `docker compose up -d --build`
+docker compose exec bff env | egrep 'BTCPAY_(URL|ADMIN_API_KEY|MASTER_KEY|WEBHOOK_URL)'
+docker compose exec bff curl -sS http://localhost:4000/healthz
+```
 
 ## Local development (optional)
 Local development still uses pnpm workspaces. Install pnpm (via Corepack) and bootstrap dependencies:
@@ -88,9 +103,9 @@ You can also spin up the Docker stack locally with the same production instructi
 - `BTCPAY_WEBHOOK_URL=https://api.paypay.iddqd.in/api/hooks/btcpay`
 - `TRUST_PROXY=1`
 - `NODE_ENV=production`
-- Add them to `deploy/docker/.env` (or your deployment-specific `.env`).
+- Add them to `infra/env/.env` (or your deployment-specific environment source for the BFF).
 
-If your edge or proxy strips the `/api` prefix before reaching the BFF, configure `BTCPAY_WEBHOOK_URL` without `/api` and align the routing rules accordingly.
+If your edge or proxy strips the `/api` prefix before reaching the BFF, configure `BTCPAY_WEBHOOK_URL` without `/api` and align the routing rules accordingly. By default, we use `https://$PAYPAY_API_DOMAIN/api/hooks/btcpay`.
 
 ## BTCPay admin API key
 - Create a server-admin API key in **BTCPay Server → Server Settings → Access Tokens**.

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -1,0 +1,4 @@
+# Used by docker-compose for variable substitution and proxy config
+PAYPAY_DOMAIN=paypay.iddqd.in
+PAYPAY_API_DOMAIN=api.paypay.iddqd.in
+CADDY_ADMIN_EMAIL=admin@example.com

--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -1,44 +1,36 @@
-# Global deployment configuration for the PayPay stack.
-# Copy this file to infra/env/.env and fill in the secrets before running docker compose.
-
-# --- Public domains & TLS ---
-# Primary UI domain served by Caddy and Next.js (e.g. paypay.example.com)
-PAYPAY_DOMAIN=
-# Public API domain for the NestJS BFF (e.g. api.paypay.example.com)
-PAYPAY_API_DOMAIN=
-# Email used by Caddy when requesting certificates from Let's Encrypt/ZeroSSL
-CADDY_ADMIN_EMAIL=
-
-# --- Frontend (Next.js) ---
-# Public origin of the BFF; must be https://<PAYPAY_API_DOMAIN>
-NEXT_PUBLIC_BFF_URL=
-# Base path used by the frontend when calling the BFF (typically just /api)
-NEXT_PUBLIC_API_BASE=/api
-
-# --- BFF (NestJS) ---
-# Browser origin allowed by CORS; must be https://<PAYPAY_DOMAIN>
-FRONTEND_ORIGIN=
-# URL of the BTCPay Server instance (legacy name kept for compatibility)
-BTCPAY_URL=
-# Alternative variable name for BTCPAY_URL if you prefer BASE_URL semantics
-BTCPAY_BASE_URL=
-BTCPAY_API_KEY=
-BTCPAY_WEBHOOK_SECRET=
-STORE_ID=
-BFF_URL=http://bff:4000
-JWT_ACCESS_TOKEN_SECRET=
-JWT_REFRESH_TOKEN_SECRET=
-
-# --- Proxies ---
-# Trust the first proxy (Caddy/Ingress). Can be: true|false|number|string
+# ===== App runtime (BFF) =====
+NODE_ENV=production
 TRUST_PROXY=1
 
-# --- Data stores ---
+# Public origins
+FRONTEND_ORIGIN=https://paypay.iddqd.in
+NEXT_PUBLIC_BFF_URL=https://api.paypay.iddqd.in
+NEXT_PUBLIC_API_BASE=/api
+
+# ===== BTCPay (BFF reads these) =====
+BTCPAY_URL=https://pay.iddqd.in
+# Server-admin API key (BTCPay → Server Settings → Access Tokens)
+BTCPAY_ADMIN_API_KEY=REPLACE_ME
+# Envelope master key: base64-encoded 32 bytes
+BTCPAY_MASTER_KEY=REPLACE_ME_BASE64_32_BYTES
+# Webhook endpoint that Caddy proxies to BFF (note the /api prefix)
+BTCPAY_WEBHOOK_URL=https://api.paypay.iddqd.in/api/hooks/btcpay
+
+# Optional health probe creds
+BTCPAY_HEALTH_STORE_ID=
+BTCPAY_HEALTH_API_KEY=
+
+# ===== JWT secrets =====
+JWT_ACCESS_TOKEN_SECRET=REPLACE_ME_LONG_HEX
+JWT_REFRESH_TOKEN_SECRET=REPLACE_ME_LONG_HEX
+
+# ===== Postgres (runtime) =====
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=paypay
 POSTGRES_USER=paypay
 POSTGRES_PASSWORD=paypay
 
+# ===== Redis (runtime) =====
 REDIS_HOST=redis
 REDIS_PORT=6379


### PR DESCRIPTION
## Summary
- update `infra/env/.env.example` to hold the BFF/frontend runtime variables expected by the stack
- add `deploy/docker/.env.example` for docker-compose domain and proxy substitutions
- expand the README with env-file workflows and verification commands for the compose deployment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da7b5b5820832fa3d6bd64063e1f1e