### PR TITLE
Refine BTCPay invoice configuration

### DIFF
--- a/apps/bff/src/btcpay/btcpay.service.ts
+++ b/apps/bff/src/btcpay/btcpay.service.ts
@@ -199,8 +199,37 @@ export class BtcpayService {
     }
   }
 
-  async createInvoice(host: string | undefined, apiKey: string, storeId: string, payload: CreateInvoiceRequest) {
-    const http = this.createHttp(host ?? this.config.baseUrl, {
+  async createInvoice(opts: {
+    storeId: string;
+    payload: CreateInvoiceRequest;
+    apiKey?: string;
+    host?: string;
+  }) {
+    const host = opts.host ?? process.env.BTCPAY_SERVER_URL ?? this.config.baseUrl;
+    if (!host) {
+      throw new InternalServerErrorException('BTCPay host is not configured');
+    }
+
+    const apiKey =
+      opts.apiKey ??
+      (await this.getStoreApiKeySafe(opts.storeId)) ??
+      process.env.BTCPAY_DEFAULT_API_KEY ??
+      undefined;
+
+    if (!apiKey) {
+      throw new InternalServerErrorException('BTCPay API key is not configured');
+    }
+
+    return this.doCreateInvoice(host, apiKey, opts.storeId, opts.payload);
+  }
+
+  private async getStoreApiKeySafe(_storeId: string): Promise<string | undefined> {
+    // TODO: Implement scoped API key lookup once store configuration is persisted.
+    return undefined;
+  }
+
+  private async doCreateInvoice(host: string, apiKey: string, storeId: string, payload: CreateInvoiceRequest) {
+    const http = this.createHttp(host, {
       Authorization: `token ${apiKey}`
     });
     try {

--- a/apps/bff/src/invoices/invoices.controller.ts
+++ b/apps/bff/src/invoices/invoices.controller.ts
@@ -33,10 +33,13 @@ export class InvoicesController {
       throw new BadRequestException('Missing store identifier');
     }
 
-    return this.btcpayService.createInvoice(storeId, {
-      amount: body.amount,
-      currency: body.currency,
-      metadata: body.metadata
+    return this.btcpayService.createInvoice({
+      storeId,
+      payload: {
+        amount: body.amount,
+        currency: body.currency,
+        metadata: body.metadata
+      }
     });
   }
 }

--- a/apps/bff/src/tenants/tenants.service.ts
+++ b/apps/bff/src/tenants/tenants.service.ts
@@ -196,10 +196,15 @@ export class TenantsService {
 
     const apiKey = this.encryptionService.decrypt(store.apiKeyCiphertext, store.apiKeyDekWrapped);
     try {
-      const invoice = await this.btcpayService.createInvoice(store.btcpayHost, apiKey, store.btcpayStoreId, {
-        amount: dto.amount,
-        currency: dto.currency,
-        metadata: dto.metadata ?? {}
+      const invoice = await this.btcpayService.createInvoice({
+        storeId: store.btcpayStoreId,
+        host: store.btcpayHost,
+        apiKey,
+        payload: {
+          amount: dto.amount,
+          currency: dto.currency,
+          metadata: dto.metadata ?? {}
+        }
       });
       return {
         invoiceId: invoice.id,

--- a/infra/env/.env.bff.example
+++ b/infra/env/.env.bff.example
@@ -1,4 +1,6 @@
 # Secrets and configuration for the BFF service.
+BTCPAY_SERVER_URL=
+BTCPAY_DEFAULT_API_KEY=
 BTCPAY_URL=
 BTCPAY_API_KEY=
 STORE_ID=

--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -8,6 +8,8 @@ NEXT_PUBLIC_BFF_URL=https://api.paypay.iddqd.in
 NEXT_PUBLIC_API_BASE=/api
 
 # ===== BTCPay (BFF reads these) =====
+BTCPAY_SERVER_URL=https://pay.iddqd.in
+BTCPAY_DEFAULT_API_KEY=
 BTCPAY_URL=https://pay.iddqd.in
 # Server-admin API key (BTCPay → Server Settings → Access Tokens)
 BTCPAY_ADMIN_API_KEY=REPLACE_ME


### PR DESCRIPTION
## Summary
- resolve BTCPay host and API key inside `BtcpayService.createInvoice` with a helper for the HTTP call and a store key lookup placeholder
- update invoice creation call sites to use the new object-based signature
- document the BTCPay server URL and default API key variables in the environment examples

## Testing
- pnpm -r build

------
https://chatgpt.com/codex/tasks/task_e_68da8066e1f8832fa69db927d6cc8aa1