### PR TITLE
Fix PNPM store handling and health controller injection

### DIFF
--- a/apps/bff/Dockerfile
+++ b/apps/bff/Dockerfile
@@ -3,7 +3,7 @@ ARG NODE_VERSION=22-alpine
 FROM node:${NODE_VERSION} AS base
 ENV PNPM_HOME=/pnpm
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+RUN corepack enable && pnpm config set store-dir /pnpm/store
 WORKDIR /opt/app
 ENV NODE_ENV=production
 
@@ -25,6 +25,7 @@ RUN pnpm --filter bff... build
 FROM base AS runtime
 WORKDIR /opt/app
 COPY --from=deps /opt/app/node_modules ./node_modules
+COPY --from=deps /pnpm/store /pnpm/store
 COPY --from=deps /opt/app/package.json ./
 COPY --from=deps /opt/app/pnpm-lock.yaml ./
 COPY --from=deps /opt/app/pnpm-workspace.yaml ./

--- a/apps/bff/src/health/health.controller.ts
+++ b/apps/bff/src/health/health.controller.ts
@@ -1,10 +1,14 @@
 import { Controller, Get, InternalServerErrorException, ServiceUnavailableException } from '@nestjs/common';
 import { BtcpayService } from '../btcpay/btcpay.service';
 import { DataSource } from 'typeorm';
+import { InjectDataSource } from '@nestjs/typeorm';
 
 @Controller()
 export class HealthController {
-  constructor(private readonly btcpayService: BtcpayService, private readonly dataSource: DataSource) {}
+  constructor(
+    private readonly btcpayService: BtcpayService,
+    @InjectDataSource() private readonly dataSource: DataSource,
+  ) {}
 
   @Get('health')
   health() {


### PR DESCRIPTION
## Summary
- persist the PNPM store in the BFF runtime container to keep dependencies available
- inject the TypeORM DataSource via NestJS decorators for the health controller

## Testing
- pnpm --filter bff lint *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dae7eaccc0832f873c5cd120c0092b