### PR TITLE
Fix BFF Docker image dependencies

### DIFF
--- a/apps/bff/package.json
+++ b/apps/bff/package.json
@@ -35,7 +35,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@nestjs/cli": "^11.0.1",
+    "@nestjs/cli": "^11.4.1",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.7",
     "@types/jest": "^29.5.14",

--- a/deploy/docker/bff.Dockerfile
+++ b/deploy/docker/bff.Dockerfile
@@ -39,16 +39,14 @@ FROM deps-build AS build
 RUN pnpm --filter ./apps/bff... build
 
 ########################
-# Prod deps only (prune)
+# Prod deps only (self-contained deploy)
 ########################
 FROM base AS deps-prod
-# Fetch prod deps separately to keep runtime lean
+# Fetch prod deps into store
 RUN pnpm fetch --prod --frozen-lockfile
 COPY . .
-RUN pnpm -r \
-  --filter ./packages/sdk... \
-  --filter ./apps/bff... \
-  install --offline --prod --frozen-lockfile
+# Build self-contained deployment package for BFF and its dependencies
+RUN pnpm --filter ./apps/bff^... --prod deploy /out
 
 ########################
 # Runtime
@@ -61,10 +59,9 @@ WORKDIR /opt/app
 RUN addgroup -S app && adduser -S app -G app
 USER app
 
-# Prod dependencies and build artefacts
-COPY --chown=app:app --from=deps-prod /work/apps/bff/node_modules ./node_modules
-COPY --chown=app:app --from=build     /work/apps/bff/dist         ./dist
-COPY --chown=app:app --from=deps-prod /work/apps/bff/package.json ./package.json
+# Production dependencies and artefacts
+COPY --chown=app:app --from=deps-prod /out/bff/ ./
+COPY --chown=app:app --from=build     /work/apps/bff/dist ./dist
 
 # Early failure if reflect-metadata is missing
 RUN node -e "require('reflect-metadata'); console.log('reflect-metadata present')"


### PR DESCRIPTION
## Summary
- use `pnpm deploy` to assemble a self-contained production dependency set for the BFF workspace
- copy the deployed BFF workspace output from `/out/bff` into the runtime image so symlinks remain valid
- bump the BFF dev dependency on `@nestjs/cli` to `^11.4.1` so the build stage has the CLI available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dafba6ae8c832face1413100b039dc