### PR TITLE
Harden pnpm caching and BFF runtime healthcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['22.x']
+        node-version: ['22.14.0']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
@@ -21,7 +21,18 @@ jobs:
       - name: Prepare pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@9 --activate
+          corepack prepare pnpm@9.15.4 --activate
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ matrix.node-version }}-9.15.4-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-${{ matrix.node-version }}-9.15.4-
+            ${{ runner.os }}-pnpm-
       - name: pnpm version
         run: pnpm -v
       - name: Install dependencies

--- a/deploy/docker/bff.Dockerfile
+++ b/deploy/docker/bff.Dockerfile
@@ -4,9 +4,11 @@
 # Base image with pnpm
 ########################
 FROM node:22-alpine AS base
+ARG PNPM_VERSION=9.15.4
 ENV PNPM_HOME=/pnpm
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable \
+  && corepack prepare pnpm@${PNPM_VERSION} --activate \
   && pnpm config set store-dir /pnpm/store
 WORKDIR /opt/app
 
@@ -53,10 +55,14 @@ RUN pnpm --filter ./apps/bff... --prod deploy /out
 FROM node:22-alpine AS runtime
 ENV NODE_ENV=production
 WORKDIR /opt/app
-RUN addgroup -S app && adduser -S app -G app
+RUN addgroup -S app \
+  && adduser -S app -G app \
+  && apk add --no-cache dumb-init
 USER app
-COPY --chown=app:app --from=deploy /out/bff/ ./
+COPY --chown=app:app --from=deploy /out/*/ ./
 COPY --chown=app:app --from=build /opt/app/apps/bff/dist ./dist
+EXPOSE 3000
 HEALTHCHECK --interval=15s --timeout=3s --start-period=20s --retries=5 \
-  CMD wget -qO- http://127.0.0.1:3000/health >/dev/null 2>&1 || exit 1
+  CMD node -e "require('http').get('http://127.0.0.1:3000/health', r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
+ENTRYPOINT ["dumb-init", "--"]
 CMD ["node", "dist/main.js"]

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "paypay",
   "private": true,
   "version": "0.1.0",
-  "packageManager": "pnpm@9.x",
+  "packageManager": "pnpm@9.15.4",
   "workspaces": [
     "apps/frontend",
     "apps/bff",
     "packages/sdk"
   ],
   "engines": {
-    "node": ">=22.14.0",
+    "node": "22.14.x",
     "pnpm": ">=9"
   },
   "engineStrict": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,7 +124,7 @@ importers:
         version: 3.25.76
     devDependencies:
       '@nestjs/cli':
-        specifier: ^11.0.1
+        specifier: 11.0.10
         version: 11.0.10(@types/node@22.18.6)
       '@nestjs/schematics':
         specifier: ^11.0.0


### PR DESCRIPTION
## Summary
- fetch the pnpm store path dynamically and incorporate node/pnpm versions into the cache key in CI
- add dumb-init and a Node-based HTTP healthcheck to the BFF Docker runtime image

## Testing
- pnpm -w install --frozen-lockfile

------
https://chatgpt.com/codex/tasks/task_e_68db0fd66744832f8c9214835d8eb5a7