### PR TITLE
Ensure BFF runtime and migrations load reflect-metadata

### DIFF
--- a/apps/bff/docker-entrypoint.sh
+++ b/apps/bff/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [ -f dist/scripts/migrate.js ]; then
-  node dist/scripts/migrate.js
+  node -r reflect-metadata dist/scripts/migrate.js
 fi
 
-exec node dist/main.js
+exec node -r reflect-metadata dist/main.js

--- a/apps/bff/package.json
+++ b/apps/bff/package.json
@@ -52,10 +52,5 @@
     "ts-jest": "^29.3.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "reflect-metadata": "^0.2.2"
-    }
   }
 }

--- a/deploy/docker/bff.Dockerfile
+++ b/deploy/docker/bff.Dockerfile
@@ -47,11 +47,8 @@ RUN pnpm --filter ./packages/sdk... build \
 # Prepare production bundle for the BFF
 ########################
 FROM build AS deploy
-# Ensure hoisted node_modules in the deploy artifact
-RUN mkdir -p /out \
-  && echo "shamefully-hoist=true" > /out/.npmrc \
-  && echo "node-linker=hoisted" >> /out/.npmrc \
-  && echo "public-hoist-pattern[]=*" >> /out/.npmrc
+# Ensure /out is empty and produce hoisted layout via CLI flags
+RUN rm -rf /out && mkdir -p /out
 RUN pnpm --filter ./apps/bff... --prod \
   --node-linker=hoisted --shamefully-hoist \
   deploy /out
@@ -66,7 +63,7 @@ RUN addgroup -S app \
   && adduser -S app -G app \
   && apk add --no-cache dumb-init
 USER app
-# Flatten deploy output into /opt/app (expects single filtered project)
+# Flatten the single filtered package into /opt/app
 COPY --chown=app:app --from=deploy /out/*/ ./
 COPY --chown=app:app --from=build /opt/app/apps/bff/dist ./dist
 EXPOSE 3000

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test"
   },
+  "pnpm": {
+    "overrides": {
+      "reflect-metadata": "^0.2.2"
+    }
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.13.0",
     "@typescript-eslint/parser": "^8.13.0",


### PR DESCRIPTION
## Summary
- ensure the BFF deploy stage prepares an empty /out directory and hoists via pnpm CLI flags
- flatten the deploy artifact into the runtime image and retain reflect-metadata pre-require
- centralize the reflect-metadata override in the root package.json for production builds and remove the ignored subpackage override
- ensure the Docker entrypoint runs migrations and the app with the reflect-metadata prerequirement

## Testing
- docker compose -f deploy/docker/docker-compose.yml build bff *(fails: docker not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbbbaca524832f9e1a9bd27a4f62d8