### PR TITLE
fix: remove redundant reflect-metadata preload in BFF prod start

### DIFF
--- a/apps/bff/package.json
+++ b/apps/bff/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "nest build",
-    "start:prod": "node -r reflect-metadata dist/main.js",
+    "start:prod": "node dist/main.js",
     "migrate": "node -r reflect-metadata dist/scripts/migrate.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- update the BFF production start script to rely on the in-app reflect-metadata import

## Testing
- pnpm -w i

------
https://chatgpt.com/codex/tasks/task_e_68dbcb660d74832fb59dccb2dfe8cd8c