### PR TITLE
Centralize environment secrets and validate BFF config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ yarn-error.log*
 .volumes/
 infra/env/.env
 infra/env/.env.local
+deploy/docker/.env

--- a/README.md
+++ b/README.md
@@ -31,64 +31,56 @@ PayPay is a monorepo housing the Next.js merchant portal, NestJS BFF, and a type
 - `infra/env` – Environment templates for local and production setups.
 - `docs/` – Architecture and privacy references.
 
-## Environment layout
+## Deployment
 
-The stack uses two complementary dotenv files:
+### Configuration & Secrets
 
-### 1. `deploy/docker/.env` (public Compose variables)
-- Loaded automatically by `docker compose` for variable substitution.
-- Safe to commit with example values; contains only public data such as domains and browser-facing URLs.
-- Populate it from the template:
-  ```bash
-  cp deploy/docker/.env.example deploy/docker/.env
-  ```
-- Required keys:
-  - `PAYPAY_DOMAIN`, `PAYPAY_API_DOMAIN`
-  - `NEXT_PUBLIC_BFF_URL` (e.g. `https://api.example.com`), `NEXT_PUBLIC_API_BASE` (e.g. `https://api.example.com/api`)
-  - `FRONTEND_ORIGIN` (e.g. `https://app.example.com`)
-  - `CADDY_ADMIN_EMAIL`
-  - Keep these values in sync with the corresponding entries in `infra/env/.env`.
+All runtime configuration is provided via environment variables. Use a single canonical file at `infra/env/.env` (do **not** commit real secrets). An example template is at `infra/env/.env.example`.
 
-### 2. `infra/env/.env` (secrets + runtime configuration)
-- **Single source of truth** for private configuration shared across services.
-- Mounted into containers via the `env_file` directive in `deploy/docker/docker-compose.yml`.
-- Create it from the example and keep it out of Git:
-  ```bash
-  cp infra/env/.env.example infra/env/.env
-  ```
-- Fill every value before production. Leave optional entries blank if you do not use that integration.
-- Public values such as `FRONTEND_ORIGIN` and `NEXT_PUBLIC_*` should match the contents of `deploy/docker/.env` so Compose
-  validation and runtime configuration stay aligned.
+#### Critical secrets
+- `COOKIE_SECRET` — HMAC key for signed HttpOnly cookies (anti-tampering for CSRF/refresh cookies). **Min 32 bytes entropy** (recommend Base64-encoded 32 random bytes).
+- `JWT_ACCESS_TOKEN_SECRET`, `JWT_REFRESH_TOKEN_SECRET` — JWT signing secrets; must be different from `COOKIE_SECRET`.
 
-### Generating sensitive values
-- JWT signing keys (used by the BFF):
-  ```bash
-  openssl rand -hex 32  # JWT_ACCESS_TOKEN_SECRET
-  openssl rand -hex 32  # JWT_REFRESH_TOKEN_SECRET
-  ```
-- BTCPay envelope master key (used to wrap store secrets):
-  ```bash
-  openssl rand -base64 32  # BTCPAY_MASTER_KEY
-  ```
+Generate strong secrets (any method below is OK):
+```bash
+openssl rand -base64 32
+# or
+node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+# or use the helper script:
+scripts/gen-secrets.sh >> infra/env/.env
+```
 
-## Configuration (Docker/Caddy)
+#### BTCPay integration
+- `BTCPAY_SERVER_URL` — e.g. `https://pay.iddqd.in`
+- `BTCPAY_ADMIN_API_KEY` — admin API key used by BFF for store provisioning & health checks
+- `BTCPAY_WEBHOOK_URL` — public BFF endpoint for BTCPay webhooks, e.g. `https://api.paypay.iddqd.in/api/hooks/btcpay`
+- Optional health probe: `BTCPAY_HEALTH_STORE_ID`, `BTCPAY_HEALTH_API_KEY`
 
-- **CADDY_ADMIN_EMAIL** (Required) – Used by the Caddy global options block to register the ACME account and receive renewal
-  notices. Caddy fails to start when the value is missing.
-- Health probes – Caddy replies to `/healthz` with `200 OK` for liveness checks, while `/health` and `/readyz` are forwarded to the BFF for application readiness.
-- Set the value in `deploy/docker/.env`; Docker Compose passes it through to the Caddy container.
-- Security: never commit the real `infra/env/.env` file. Keep production secrets outside of version control and distribute them
-  via your secret management workflow.
-- Note: Docker Compose V2 no longer requires a top-level `version` field; removing it silences the deprecation warning.
+#### Domains / Origins
+- `PAYPAY_DOMAIN`, `PAYPAY_API_DOMAIN`, `FRONTEND_ORIGIN`, `NEXT_PUBLIC_BFF_URL`, `NEXT_PUBLIC_API_BASE`
+
+#### Database & SMTP
+- Either `DATABASE_URL` or `POSTGRES_*` (host/user/password/db)
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM_EMAIL`
+
+#### TLS/ACME
+- `CADDY_ADMIN_EMAIL` — contact email for certificate issuer
+
+### Single source of truth for env
+We use **`infra/env/.env`** as the only source of truth. Docker Compose is invoked with:
+```bash
+cd deploy/docker
+docker compose --env-file ../../infra/env/.env up -d --build
+```
+Compose services also reference the same file via `env_file:` to inject variables at container runtime.
 
 ## Quick start (deploy/docker)
 
-1. `cp deploy/docker/.env.example deploy/docker/.env && vi deploy/docker/.env`
-2. `cp infra/env/.env.example infra/env/.env && vi infra/env/.env`
-3. Ensure both files contain the same values for shared keys (JWT, BTCPay, database, SMTP).
-4. `cd deploy/docker`
-5. `docker compose up -d --build`
-6. Validate:
+1. `cp infra/env/.env.example infra/env/.env && vi infra/env/.env`
+2. `cp deploy/docker/.env.example deploy/docker/.env` (placeholder only; keep values in sync with `infra/env/.env` if you override any Compose defaults.)
+3. `cd deploy/docker`
+4. `docker compose --env-file ../../infra/env/.env up -d --build`
+5. Validate:
    - `docker compose ps` reports all services as `running (healthy)`
    - `curl http://localhost:3000/health` returns `{"status":"ok"}`
    - `docker compose logs -n 50 caddy` has no "parsing caddyfile tokens for 'email'" error
@@ -101,7 +93,7 @@ The stack uses two complementary dotenv files:
 - The ability to receive HTTPS traffic on port 443 (Caddy terminates TLS and renews certificates automatically).
 
 ### Configuration
-1. Prepare `deploy/docker/.env` and `infra/env/.env` using the templates described above.
+1. Prepare `infra/env/.env` using the canonical template (optionally mirror non-secret placeholders in `deploy/docker/.env`).
 2. Review `infra/env/.env` and ensure domains, BTCPay credentials, JWT secrets, and database settings are correct for your deployment. `BTCPAY_WEBHOOK_URL` should point to the BFF webhook endpoint proxied by Caddy (default: `https://$PAYPAY_API_DOMAIN/api/hooks/btcpay`).
 3. From the server, build and start the stack (no Node.js or pnpm required on the host):
    ```bash
@@ -168,17 +160,20 @@ You can also spin up the Docker stack locally with the same production instructi
 - Set the result as `BTCPAY_MASTER_KEY` in the BFF environment.
 
 ### Mandatory environment variables
-- Public (place in `deploy/docker/.env`):
+- Store canonical values in `infra/env/.env` (single source of truth). Mirror non-secret placeholders in `deploy/docker/.env` only if you rely on Compose interpolation without the `--env-file` flag.
+- Domains and public URLs:
   - `PAYPAY_DOMAIN`, `PAYPAY_API_DOMAIN`
   - `FRONTEND_ORIGIN` (e.g. `https://app.example.com`)
   - `NEXT_PUBLIC_BFF_URL` (e.g. `https://api.example.com`), `NEXT_PUBLIC_API_BASE` (e.g. `https://api.example.com/api`)
-- Private (place in `infra/env/.env`):
+- BTCPay + auth secrets:
   - `BTCPAY_SERVER_URL`
   - `BTCPAY_ADMIN_API_KEY`
   - `BTCPAY_MASTER_KEY`
   - `BTCPAY_WEBHOOK_URL`
-  - `JWT_ACCESS_TOKEN_SECRET`, `JWT_REFRESH_TOKEN_SECRET`
+  - `JWT_ACCESS_TOKEN_SECRET`, `JWT_REFRESH_TOKEN_SECRET`, `COOKIE_SECRET`
+- Platform services:
   - `POSTGRES_*` or `DATABASE_URL`
+  - `SMTP_*`
   - `TRUST_PROXY` (override if your proxy chain differs)
   - `NODE_ENV=production`
 

--- a/apps/bff/src/config/env.validation.ts
+++ b/apps/bff/src/config/env.validation.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+
+const base64Min32 = z.string().refine((val) => {
+  try {
+    const bytes = Buffer.from(val, 'base64');
+    return bytes.length >= 32;
+  } catch {
+    return false;
+  }
+}, 'must be Base64 of at least 32 bytes');
+
+export const EnvSchema = z.object({
+  NODE_ENV: z.string().default('production'),
+  PORT: z.coerce.number().default(3000),
+  TRUST_PROXY: z.coerce.number().default(1),
+
+  COOKIE_SECRET: z.string().min(32, 'must be at least 32 chars or Base64'),
+  JWT_ACCESS_TOKEN_SECRET: z.string().min(32),
+  JWT_REFRESH_TOKEN_SECRET: z.string().min(32),
+
+  FRONTEND_ORIGIN: z.string().url(),
+  PAYPAY_DOMAIN: z.string(),
+  PAYPAY_API_DOMAIN: z.string(),
+
+  BTCPAY_SERVER_URL: z.string().url(),
+  BTCPAY_ADMIN_API_KEY: z.string().min(1),
+  BTCPAY_WEBHOOK_URL: z.string().url(),
+  BTCPAY_MASTER_KEY: base64Min32.optional(),
+  BTCPAY_HEALTH_STORE_ID: z.string().optional(),
+  BTCPAY_HEALTH_API_KEY: z.string().optional(),
+
+  DATABASE_URL: z.string().optional(),
+  POSTGRES_HOST: z.string().default('postgres'),
+  POSTGRES_PORT: z.coerce.number().default(5432),
+  POSTGRES_USER: z.string().default('paypay'),
+  POSTGRES_PASSWORD: z.string().default('paypay'),
+  POSTGRES_DB: z.string().default('paypay'),
+
+  SMTP_HOST: z.string().optional(),
+  SMTP_PORT: z.coerce.number().optional(),
+  SMTP_USERNAME: z.string().optional(),
+  SMTP_PASSWORD: z.string().optional(),
+  SMTP_FROM_EMAIL: z.string().optional(),
+});
+
+export type Env = z.infer<typeof EnvSchema>;
+
+export function getEnv(): Env {
+  const parsed = EnvSchema.safeParse(process.env);
+  if (!parsed.success) {
+    // Pretty print all errors and exit fast
+    console.error('[Config] Invalid environment variables:', parsed.error.format());
+    process.exit(1);
+  }
+  const e = parsed.data;
+  // Additional security assertions
+  if (e.COOKIE_SECRET === e.JWT_ACCESS_TOKEN_SECRET || e.COOKIE_SECRET === e.JWT_REFRESH_TOKEN_SECRET) {
+    console.error('[Config] COOKIE_SECRET must differ from JWT secrets.');
+    process.exit(1);
+  }
+  if (e.NODE_ENV === 'production' && e.FRONTEND_ORIGIN.startsWith('http://')) {
+    console.error('[Config] FRONTEND_ORIGIN must be https:// in production.');
+    process.exit(1);
+  }
+  for (const [key, value] of Object.entries(e)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    process.env[key] = typeof value === 'string' ? value : String(value);
+  }
+  return e;
+}

--- a/apps/bff/src/main.ts
+++ b/apps/bff/src/main.ts
@@ -1,21 +1,27 @@
 import 'reflect-metadata';
 import { RequestMethod, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
-import { ConfigService } from '@nestjs/config';
 import { useContainer } from 'class-validator';
 import helmet from 'helmet';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
-import csrf from 'csurf';
+import csurf from 'csurf';
 import type { NextFunction, Request, Response } from 'express';
 import { Logger } from 'nestjs-pino';
 import { AppModule } from './app.module';
 import { json } from 'express';
 import { CSRF_SECRET_COOKIE_NAME } from './auth/auth.constants';
+import { getEnv } from './config/env.validation';
 
-function parseTrustProxy(v?: string): any {
+function parseTrustProxy(v?: string | number | boolean): any {
   if (v === undefined) {
     return 1;
+  }
+  if (typeof v === 'number') {
+    return v;
+  }
+  if (typeof v === 'boolean') {
+    return v;
   }
   const normalized = v.trim();
   if (normalized === '') {
@@ -29,18 +35,16 @@ function parseTrustProxy(v?: string): any {
 }
 
 async function bootstrap() {
+  const env = getEnv();
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
-  const configService = app.get(ConfigService);
   const logger = app.get(Logger);
   app.useLogger(logger);
 
   useContainer(app.select(AppModule), { fallbackOnErrors: true });
 
-  const isProduction = configService.get<string>('NODE_ENV') === 'production';
+  const isProduction = env.NODE_ENV === 'production';
   const defaultOrigin = 'https://paypay.iddqd.in';
-  const configuredOrigins = configService
-    .get<string>('FRONTEND_ORIGIN')
-    ?.split(',')
+  const configuredOrigins = env.FRONTEND_ORIGIN.split(',')
     .map((value) => value.trim())
     .filter((value) => value.length > 0);
   const allowedOrigins = Array.from(new Set([defaultOrigin, ...(configuredOrigins ?? [])]));
@@ -56,14 +60,12 @@ async function bootstrap() {
     })
   );
 
-  const cookieSecret = configService.get<string>('COOKIE_SECRET');
-  app.use(cookieParser(cookieSecret));
+  app.use(cookieParser(env.COOKIE_SECRET));
 
   const httpAdapter = app.getHttpAdapter();
   const type = httpAdapter.getType();
   const instance = httpAdapter.getInstance();
-  const trustProxyRaw = configService.get<string>('TRUST_PROXY') ?? '1';
-  const trustProxyValue = parseTrustProxy(trustProxyRaw);
+  const trustProxyValue = parseTrustProxy(env.TRUST_PROXY);
 
   if (type === 'fastify') {
     (instance as any).trustProxy = trustProxyValue;
@@ -86,12 +88,13 @@ async function bootstrap() {
       })
     );
 
-    const csrfMiddleware = csrf({
+    const csrfMiddleware = csurf({
       cookie: {
         key: CSRF_SECRET_COOKIE_NAME,
         httpOnly: true,
         sameSite: 'lax',
         secure: isProduction,
+        signed: true,
         path: '/'
       },
       ignoreMethods: ['GET', 'HEAD', 'OPTIONS'],
@@ -120,7 +123,7 @@ async function bootstrap() {
     ]
   });
 
-  const port = configService.get<number>('PORT') ?? 3000;
+  const port = env.PORT ?? 3000;
   await app.listen(port, '0.0.0.0');
   logger.log(`🚀 BFF is running at http://0.0.0.0:${port}`);
 }

--- a/apps/bff/test/auth.e2e-spec.ts
+++ b/apps/bff/test/auth.e2e-spec.ts
@@ -16,7 +16,7 @@ describe('AuthModule (e2e)', () => {
     }).compile();
 
     app = moduleRef.createNestApplication();
-    app.use(cookieParser());
+    app.use(cookieParser(process.env.COOKIE_SECRET));
     app.useGlobalPipes(
       new ValidationPipe({
         whitelist: true,

--- a/apps/bff/test/hooks.e2e-spec.ts
+++ b/apps/bff/test/hooks.e2e-spec.ts
@@ -15,7 +15,7 @@ describe('BTCPay webhook CSRF bypass (e2e)', () => {
     }).compile();
 
     app = moduleRef.createNestApplication();
-    app.use(cookieParser());
+    app.use(cookieParser(process.env.COOKIE_SECRET));
     app.useGlobalPipes(
       new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true })
     );

--- a/apps/bff/test/setup-env.ts
+++ b/apps/bff/test/setup-env.ts
@@ -3,7 +3,11 @@ process.env.DB_TYPE = process.env.DB_TYPE ?? 'sqlite';
 process.env.DB_DATABASE = process.env.DB_DATABASE ?? ':memory:';
 process.env.JWT_ACCESS_TOKEN_SECRET = process.env.JWT_ACCESS_TOKEN_SECRET ?? 'test-access-secret';
 process.env.JWT_REFRESH_TOKEN_SECRET = process.env.JWT_REFRESH_TOKEN_SECRET ?? 'test-refresh-secret';
+process.env.COOKIE_SECRET =
+  process.env.COOKIE_SECRET ?? 'test-cookie-secret-should-be-at-least-32-characters';
 process.env.FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN ?? 'http://localhost:3000';
+process.env.PAYPAY_DOMAIN = process.env.PAYPAY_DOMAIN ?? 'paypay.test';
+process.env.PAYPAY_API_DOMAIN = process.env.PAYPAY_API_DOMAIN ?? 'api.paypay.test';
 process.env.BTCPAY_SERVER_URL = process.env.BTCPAY_SERVER_URL ?? 'https://btcpay.local';
 process.env.BTCPAY_ADMIN_API_KEY = process.env.BTCPAY_ADMIN_API_KEY ?? 'test-admin-api-key';
 process.env.BTCPAY_MASTER_KEY =

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -1,5 +1,6 @@
-# Compose defaults loaded before docker-compose.yml is parsed.
-# Copy to deploy/docker/.env and keep it in sync with infra/env/.env.
+# Example variables for Docker Compose. Do NOT put real secrets here.
+# Use infra/env/.env as the single source of truth and run:
+#   docker compose --env-file ../../infra/env/.env up -d --build
 NODE_ENV=production
 PORT=3000
 TRUST_PROXY=1
@@ -11,7 +12,6 @@ BTCPAY_SERVER_URL=https://btcpay.example.com
 BTCPAY_ADMIN_API_KEY=btcpay-admin-api-key
 BTCPAY_WEBHOOK_URL=https://api.paypay.iddqd.in/api/hooks/btcpay
 BTCPAY_MASTER_KEY=base64-encoded-32-byte-master-key
-# Optional BTCPay health probe credentials (set both or leave both empty)
 BTCPAY_HEALTH_STORE_ID=
 BTCPAY_HEALTH_API_KEY=
 DATABASE_URL=
@@ -25,12 +25,8 @@ SMTP_PORT=587
 SMTP_USERNAME=
 SMTP_PASSWORD=
 SMTP_FROM_EMAIL=
-
-# Domains and frontend URLs exposed publicly
 PAYPAY_DOMAIN=paypay.iddqd.in
 PAYPAY_API_DOMAIN=api.paypay.iddqd.in
 NEXT_PUBLIC_BFF_URL=https://api.paypay.iddqd.in
 NEXT_PUBLIC_API_BASE=https://api.paypay.iddqd.in/api
-
-# Example admin email for Caddy ACME registration. Replace in deploy/docker/.env with your real address; never commit secrets.
 CADDY_ADMIN_EMAIL=ops@example.com

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       dockerfile: apps/frontend/Dockerfile
     image: ghcr.io/paypay/frontend:latest
     restart: unless-stopped
+    env_file:
+      - ../../infra/env/.env
     environment:
       NODE_ENV: production
       NEXT_PUBLIC_BFF_URL: ${NEXT_PUBLIC_BFF_URL:?NEXT_PUBLIC_BFF_URL is required}
@@ -102,7 +104,7 @@ services:
     image: caddy:2-alpine
     restart: unless-stopped
     env_file:
-      - .env
+      - ../../infra/env/.env
     environment:
       - CADDY_ADMIN_EMAIL=${CADDY_ADMIN_EMAIL:?CADDY_ADMIN_EMAIL is required}
     ports:

--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -1,39 +1,30 @@
-# PayPay BFF runtime secrets and infrastructure configuration.
-# Copy this file to infra/env/.env and fill in every value before running docker compose.
-# Keep the resulting file in sync with deploy/docker/.env so Compose validation stays green.
-
-# Core runtime
+# Canonical example. Copy to infra/env/.env and fill in real values (never commit).
 NODE_ENV=production
 PORT=3000
 TRUST_PROXY=1
+COOKIE_SECRET=base64-32-bytes-hmac-key
 FRONTEND_ORIGIN=https://paypay.iddqd.in
-COOKIE_SECRET=please-change-me
-
-# JWT signing secrets (generate with `openssl rand -hex 32`).
-JWT_ACCESS_TOKEN_SECRET=jwt-access-secret-change-me
-JWT_REFRESH_TOKEN_SECRET=jwt-refresh-secret-change-me
-
-# Database connection (use DATABASE_URL or the individual POSTGRES_* keys).
+JWT_ACCESS_TOKEN_SECRET=base64-32-bytes-jwt-access
+JWT_REFRESH_TOKEN_SECRET=base64-32-bytes-jwt-refresh
+BTCPAY_SERVER_URL=https://pay.iddqd.in
+BTCPAY_ADMIN_API_KEY=fill-me
+BTCPAY_WEBHOOK_URL=https://api.paypay.iddqd.in/api/hooks/btcpay
+BTCPAY_MASTER_KEY=base64-32-bytes-master-key
+BTCPAY_HEALTH_STORE_ID=
+BTCPAY_HEALTH_API_KEY=
 DATABASE_URL=
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_USER=paypay
 POSTGRES_PASSWORD=paypay
 POSTGRES_DB=paypay
-
-# BTCPay Server integration.
-BTCPAY_SERVER_URL=https://btcpay.example.com
-BTCPAY_ADMIN_API_KEY=btcpay-admin-api-key
-BTCPAY_WEBHOOK_URL=https://api.paypay.iddqd.in/api/hooks/btcpay
-# Envelope encryption master key, base64-encoded 32-byte value.
-BTCPAY_MASTER_KEY=base64-encoded-32-byte-master-key
-# Optional BTCPay store used for health probes (set both or leave both blank).
-BTCPAY_HEALTH_STORE_ID=
-BTCPAY_HEALTH_API_KEY=
-
-# Outbound email (leave blank if SMTP is not configured).
 SMTP_HOST=
 SMTP_PORT=587
 SMTP_USERNAME=
 SMTP_PASSWORD=
 SMTP_FROM_EMAIL=
+PAYPAY_DOMAIN=paypay.iddqd.in
+PAYPAY_API_DOMAIN=api.paypay.iddqd.in
+NEXT_PUBLIC_BFF_URL=https://api.paypay.iddqd.in
+NEXT_PUBLIC_API_BASE=https://api.paypay.iddqd.in/api
+CADDY_ADMIN_EMAIL=ops@example.com

--- a/scripts/gen-secrets.sh
+++ b/scripts/gen-secrets.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+gen(){ openssl rand -base64 32; }
+
+echo "COOKIE_SECRET=$(gen)"
+echo "JWT_ACCESS_TOKEN_SECRET=$(gen)"
+echo "JWT_REFRESH_TOKEN_SECRET=$(gen)"
+echo "BTCPAY_MASTER_KEY=$(gen)"


### PR DESCRIPTION
## Summary
- document the single-source env workflow and secret generation commands in the README
- unify env examples, ignore real dotenv files, and load the canonical file via docker-compose env_file
- add zod-based runtime env validation, secure CSRF cookies, and a helper script for strong secret generation

## Testing
- pnpm --filter bff build
- pnpm --filter bff test

------
https://chatgpt.com/codex/tasks/task_e_68dd348df534832fb6a23a1aa1edcc56