### PR TITLE
chore: align sdk tooling for bff builds

### DIFF
--- a/apps/bff/Dockerfile
+++ b/apps/bff/Dockerfile
@@ -11,16 +11,16 @@ COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY apps/bff/package.json apps/bff/package.json
 COPY apps/frontend/package.json apps/frontend/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
-RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm fetch --filter ./packages/sdk...
-RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm fetch --filter ./apps/bff...
-RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm fetch --prod --filter ./apps/bff...
+RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm fetch \
+      --filter ./packages/sdk... \
+      --filter ./apps/bff...
 COPY . .
 ## Ensure dependencies for the SDK and BFF are installed prior to building
 RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm install --offline --frozen-lockfile \
       --filter ./packages/sdk... \
       --filter ./apps/bff...
-RUN pnpm --filter ./packages/sdk... build
-RUN pnpm --filter ./apps/bff... build
+RUN pnpm -w --filter @paypay/sdk build
+RUN pnpm -w --filter ./apps/bff... build
 
 FROM base AS runner
 ENV NODE_ENV=production

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -24,6 +24,7 @@
     "axios": "^1.7.9"
   },
   "devDependencies": {
-    "typescript": "^5.6.3"
+    "tslib": "^2.6.3",
+    "typescript": "5.6.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,9 +260,12 @@ importers:
         specifier: ^1.7.9
         version: 1.12.2
     devDependencies:
+      tslib:
+        specifier: ^2.6.3
+        version: 2.8.1
       typescript:
-        specifier: ^5.6.3
-        version: 5.9.2
+        specifier: 5.6.3
+        version: 5.6.3
 
 packages:
 
@@ -5114,6 +5117,11 @@ packages:
         optional: true
       typeorm-aurora-data-api-driver:
         optional: true
+
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -10940,6 +10948,8 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+
+  typescript@5.6.3: {}
 
   typescript@5.8.3: {}
 


### PR DESCRIPTION
## Summary
- pin the SDK TypeScript toolchain to TypeScript 5.6.3 and add tslib as a dev dependency
- refresh the pnpm lockfile to capture the new SDK tooling versions
- streamline the BFF Docker build stage to share fetch/install filters and build the SDK before the BFF package

## Testing
- pnpm --filter @paypay/sdk --workspace-root=false build

------
https://chatgpt.com/codex/tasks/task_e_68dd444d2bd4832fb028e8829c33d840