### PR TITLE
Limit Docker builds to BFF and SDK scopes

### DIFF
--- a/apps/bff/Dockerfile
+++ b/apps/bff/Dockerfile
@@ -9,7 +9,6 @@ WORKDIR /workspace
 FROM base AS build
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY apps/bff/package.json apps/bff/package.json
-COPY apps/frontend/package.json apps/frontend/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm fetch \
       --filter ./packages/sdk... \
@@ -19,8 +18,8 @@ COPY . .
 RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm install --offline --frozen-lockfile \
       --filter ./packages/sdk... \
       --filter ./apps/bff...
-RUN pnpm -w --filter @paypay/sdk build
-RUN pnpm -w --filter ./apps/bff... build
+RUN pnpm --filter @paypay/sdk build
+RUN pnpm --filter ./apps/bff... build
 
 FROM base AS runner
 ENV NODE_ENV=production
@@ -28,14 +27,17 @@ ENV PORT=3000
 WORKDIR /workspace
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY apps/bff/package.json apps/bff/package.json
-COPY apps/frontend/package.json apps/frontend/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
-RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm fetch --prod --filter ./apps/bff...
+# Ensure runtime dependencies for the BFF and SDK are cached for offline installs
+RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm fetch --prod \
+      --filter ./apps/bff... \
+      --filter @paypay/sdk
 COPY --from=build /workspace/apps/bff/dist ./apps/bff/dist
 COPY --from=build /workspace/apps/bff/package.json ./apps/bff/package.json
 COPY --from=build /workspace/apps/bff/nest-cli.json ./apps/bff/nest-cli.json
 COPY --from=build /workspace/packages ./packages
-RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm install --offline --prod --filter ./apps/bff... --frozen-lockfile
+RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm install \
+      --offline --prod --frozen-lockfile --filter ./apps/bff...
 EXPOSE 3000
 USER node
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD \

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -10,12 +10,12 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/frontend/package.json apps/frontend/package.json
 COPY apps/bff/package.json apps/bff/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
-RUN pnpm fetch
+RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm fetch --filter ./apps/frontend...
 
 FROM deps AS build
 COPY . .
-RUN pnpm install --frozen-lockfile --offline \
-  && pnpm -r build
+RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm install --offline --frozen-lockfile --filter ./apps/frontend...
+RUN pnpm --filter ./apps/frontend... build
 
 FROM node:22-alpine AS runner
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary
- scope pnpm build commands in the BFF Dockerfile to avoid touching the workspace root
- ensure the runner image prefetches BFF and SDK production dependencies while removing unused frontend artifacts
- scope the frontend Dockerfile to fetch, install, and build only the frontend workspace packages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd48774d90832fbc99709213099104