### PR TITLE
Align frontend Docker image with pinned toolchain

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM node:22-alpine AS base
+FROM node:22.14.0-alpine AS base
 ENV PNPM_HOME=/pnpm
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
@@ -17,8 +17,9 @@ COPY . .
 RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm install --offline --frozen-lockfile --filter ./apps/frontend...
 RUN pnpm --filter ./apps/frontend... build
 
-FROM node:22-alpine AS runner
+FROM node:22.14.0-alpine AS runner
 ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
 WORKDIR /app
 COPY --from=build /workspace/apps/frontend/.next/standalone ./
 COPY --from=build /workspace/apps/frontend/.next/static ./apps/frontend/.next/static

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "paypay",
   "private": true,
   "version": "0.1.0",
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm@9.11.0",
   "workspaces": [
     "apps/frontend",
     "apps/bff",


### PR DESCRIPTION
## Summary
- update the frontend Docker base and runner stages to use node 22.14.0 like the rest of the stack
- disable Next.js runtime telemetry in the production runner image
- pin the workspace packageManager to pnpm 9.11.0 for reproducible corepack installs

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd49df0390832fa8b92d1780c94b0d