### PR TITLE
Add frontend health endpoint and Docker healthcheck

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -27,4 +27,7 @@ COPY --from=build /workspace/apps/frontend/public ./apps/frontend/public
 USER node
 EXPOSE 3000
 ENV PORT=3000
+ENV HOST=0.0.0.0
+HEALTHCHECK --interval=10s --timeout=3s --start-period=15s --retries=5 \
+  CMD node -e "const http=require('http');const req=http.request({hostname:'127.0.0.1',port:3000,path:'/health',timeout:2000},res=>process.exit(res.statusCode===200?0:1));req.on('error',()=>process.exit(1));req.end()"
 CMD ["node", "apps/frontend/server.js"]

--- a/apps/frontend/app/health/route.ts
+++ b/apps/frontend/app/health/route.ts
@@ -1,5 +1,12 @@
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 
-export function GET() {
-  return NextResponse.json({ status: "ok" });
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({ ok: true });
+}
+
+export async function HEAD() {
+  return new Response(null, { status: 200 });
 }

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -15,10 +15,11 @@ services:
       bff:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
+      test: ["CMD-SHELL", "node -e \"const http=require('http');const r=http.request({hostname:'127.0.0.1',port:3000,path:'/health',timeout:2000},res=>process.exit(res.statusCode===200?0:1));r.on('error',()=>process.exit(1));r.end()\""]
+      interval: 10s
+      timeout: 3s
+      start_period: 15s
+      retries: 5
     networks:
       - paynet
 


### PR DESCRIPTION
## Summary
- add an App Router health route that responds on `/health`
- expose the Next.js runtime on `0.0.0.0` and add a container healthcheck hitting `/health`
- update the compose healthcheck to use the same `/health` endpoint

## Testing
- docker compose up -d --build *(fails: `docker` command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4bd5b458832fab27f17ac20834ca