### PR TITLE
fix: purge BFF secret fallbacks and extend healthcheck grace

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,16 @@
+.git
+infra/env
+**/.env
+**/.env.local
+**/.env.development
+**/.env.production
+node_modules
 **/node_modules
+dist
 **/dist
 **/.next
-.git
 .gitignore
 .DS_Store
+Dockerfile*
+docker-compose*
 pnpm-debug.log

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ PayPay is a monorepo housing the Next.js merchant portal, NestJS BFF, and a type
 
 ## Secrets & Env
 
-PayPay keeps every secret and runtime toggle in a single dotenv file: `infra/env/.env`. The template lives at `infra/env/.env.example`; copy it, fill in the values, and keep the real file out of Git (see `.gitignore`). Do **not** create `deploy/docker/.env` or any other shadow copies—the Docker stack, scripts, and CI tooling all read from `infra/env/.env` directly.
+PayPay keeps every secret and runtime toggle in a single dotenv file: `infra/env/.env`. The template lives at `infra/env/.env.example`; copy it, fill in the values, and keep the real file out of Git (see `.gitignore`). Do **not** create `deploy/docker/.env` or any other shadow copies—the Docker stack, scripts, and CI tooling all read from `infra/env/.env` directly. The BFF Docker image ignores `.env` files whenever `NODE_ENV=production`; Docker Compose injects `infra/env/.env` through `env_file`, so there are no baked-in fallbacks inside the container.
 
 ### Minimum secret requirements
 
@@ -42,6 +42,30 @@ You can also pipe the helper script into the file:
 ```bash
 scripts/gen-secrets.sh >> infra/env/.env
 ```
+
+### Runtime verification
+
+To confirm that only Docker Compose–provided variables reach the container, inspect the environment at runtime:
+
+```bash
+docker compose run --rm --no-deps --entrypoint env bff | egrep 'JWT|COOKIE|BTCPAY|POSTGRES|FRONTEND_ORIGIN|PORT'
+docker inspect docker-bff-1 | jq -r '.[0].Config.Env[]' | egrep 'JWT|COOKIE|BTCPAY|POSTGRES|FRONTEND_ORIGIN|PORT'
+```
+
+If you previously built images with placeholder defaults baked into the layers, perform a cold rebuild so Docker drops every cached layer before composing new images:
+
+```bash
+cd deploy/docker
+docker compose down --remove-orphans
+docker rmi ghcr.io/paypay/bff:latest ghcr.io/paypay/frontend:latest 2>/dev/null || true
+docker builder prune -af
+docker compose build --no-cache bff frontend
+docker compose up -d
+```
+
+The cache purge ensures the resulting images only contain the values provided via `infra/env/.env`. After the stack restarts, rerun the environment inspection commands above.
+
+Rotate secrets with `openssl rand -base64 32` (48 for BTCPay master keys), update `infra/env/.env`, and rebuild the stack. Never commit populated dotenv files.
 
 ### Bootstrapping Docker Compose
 

--- a/apps/bff/.dockerignore
+++ b/apps/bff/.dockerignore
@@ -1,0 +1,4 @@
+.env
+.env.*
+node_modules
+dist

--- a/apps/bff/Dockerfile
+++ b/apps/bff/Dockerfile
@@ -23,7 +23,6 @@ RUN pnpm --filter ./apps/bff... build
 
 FROM base AS runner
 ENV NODE_ENV=production
-ENV PORT=3000
 WORKDIR /workspace
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY apps/bff/package.json apps/bff/package.json
@@ -36,10 +35,12 @@ COPY --from=build /workspace/apps/bff/dist ./apps/bff/dist
 COPY --from=build /workspace/apps/bff/package.json ./apps/bff/package.json
 COPY --from=build /workspace/apps/bff/nest-cli.json ./apps/bff/nest-cli.json
 COPY --from=build /workspace/packages ./packages
+COPY --from=build /workspace/apps/bff/docker-entrypoint.sh /usr/local/bin/bff-entrypoint.sh
+RUN chmod +x /usr/local/bin/bff-entrypoint.sh
 RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm install \
       --offline --prod --frozen-lockfile --filter ./apps/bff...
 EXPOSE 3000
 USER node
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=5 CMD \
   node -e "fetch('http://127.0.0.1:' + (process.env.PORT || '3000') + '/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
-CMD ["node","apps/bff/dist/main.js"]
+ENTRYPOINT ["bff-entrypoint.sh"]

--- a/apps/bff/docker-entrypoint.sh
+++ b/apps/bff/docker-entrypoint.sh
@@ -1,8 +1,36 @@
 #!/usr/bin/env sh
 set -euo pipefail
 
+APP_DIR="/workspace/apps/bff"
+
+cd "$APP_DIR"
+
+if [ "${NODE_ENV:-production}" != "production" ] && [ -f ".env" ]; then
+  while IFS='=' read -r key value || [ -n "$key" ]; do
+    case "$key" in
+      ''|\#*) continue ;;
+    esac
+    key=${key#export }
+    key=${key#export}
+    key=$(printf '%s' "$key" | tr -d '[:space:]')
+    if [ -z "$key" ]; then
+      continue
+    fi
+    if [ -z "${!key+x}" ]; then
+      value="${value%$'\r'}"
+      while [ "${value# }" != "$value" ]; do value="${value# }"; done
+      while [ "${value#$'\t'}" != "$value" ]; do value="${value#$'\t'}"; done
+      export "$key=$value"
+    fi
+  done < .env
+fi
+
 if [ -f dist/scripts/migrate.js ]; then
   node -r reflect-metadata dist/scripts/migrate.js
+fi
+
+if [ "$#" -gt 0 ]; then
+  exec "$@"
 fi
 
 exec node -r reflect-metadata dist/main.js

--- a/apps/bff/src/app.module.ts
+++ b/apps/bff/src/app.module.ts
@@ -20,7 +20,11 @@ import { HealthController } from './health.controller';
 
 @Module({
   imports: [
-    ConfigModule.forRoot({ isGlobal: true }),
+    ConfigModule.forRoot({
+      isGlobal: true,
+      ignoreEnvFile: process.env.NODE_ENV === 'production',
+      envFilePath: process.env.NODE_ENV === 'production' ? [] : ['.env']
+    }),
     LoggerModule.forRoot({
       pinoHttp: {
         level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',

--- a/apps/bff/src/config/env.validation.ts
+++ b/apps/bff/src/config/env.validation.ts
@@ -30,11 +30,11 @@ export const EnvSchema = z.object({
   BTCPAY_HEALTH_API_KEY: z.string().optional(),
 
   DATABASE_URL: z.string().optional(),
-  POSTGRES_HOST: z.string().default('postgres'),
+  POSTGRES_HOST: z.string().min(1),
   POSTGRES_PORT: z.coerce.number().default(5432),
-  POSTGRES_USER: z.string().default('paypay'),
-  POSTGRES_PASSWORD: z.string().default('paypay'),
-  POSTGRES_DB: z.string().default('paypay'),
+  POSTGRES_USER: z.string().min(1),
+  POSTGRES_PASSWORD: z.string().min(1),
+  POSTGRES_DB: z.string().min(1),
 
   SMTP_HOST: z.string().optional(),
   SMTP_PORT: z.coerce.number().optional(),


### PR DESCRIPTION
## Summary
- require explicit Postgres credentials from the environment instead of falling back to baked defaults
- add guidance for rebuilding Docker images without cached secret layers and reiterate runtime verification commands
- give the BFF container more startup time by updating Dockerfile health checks to include a start period and extra retries

## Testing
- pnpm --filter bff build

------
https://chatgpt.com/codex/tasks/task_e_68dd6072e890832f946c63dae25728a7