### PR TITLE
fix: harden BFF environment handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,6 @@
 .git
 infra/env
-**/.env
-**/.env.local
-**/.env.development
-**/.env.production
+**/.env*
 node_modules
 **/node_modules
 dist

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To confirm that only Docker Compose–provided variables reach the container, in
 
 ```bash
 docker compose run --rm --no-deps --entrypoint env bff | egrep 'JWT|COOKIE|BTCPAY|POSTGRES|FRONTEND_ORIGIN|PORT'
-docker inspect docker-bff-1 | jq -r '.[0].Config.Env[]' | egrep 'JWT|COOKIE|BTCPAY|POSTGRES|FRONTEND_ORIGIN|PORT'
+docker inspect "$(docker compose ps -q bff)" | jq -r '.[0].Config.Env[]' | egrep 'JWT|COOKIE|BTCPAY|POSTGRES|FRONTEND_ORIGIN|PORT'
 ```
 
 If you previously built images with placeholder defaults baked into the layers, perform a cold rebuild so Docker drops every cached layer before composing new images:

--- a/apps/bff/.dockerignore
+++ b/apps/bff/.dockerignore
@@ -1,4 +1,7 @@
-.env
-.env.*
+**/.env*
+.env*
 node_modules
 dist
+../infra/env
+Dockerfile*
+docker-compose*

--- a/apps/bff/Dockerfile
+++ b/apps/bff/Dockerfile
@@ -35,12 +35,12 @@ COPY --from=build /workspace/apps/bff/dist ./apps/bff/dist
 COPY --from=build /workspace/apps/bff/package.json ./apps/bff/package.json
 COPY --from=build /workspace/apps/bff/nest-cli.json ./apps/bff/nest-cli.json
 COPY --from=build /workspace/packages ./packages
-COPY --from=build /workspace/apps/bff/docker-entrypoint.sh /usr/local/bin/bff-entrypoint.sh
-RUN chmod +x /usr/local/bin/bff-entrypoint.sh
 RUN --mount=type=cache,target=/pnpm/store,sharing=locked pnpm install \
       --offline --prod --frozen-lockfile --filter ./apps/bff...
-EXPOSE 3000
+COPY --from=build /workspace/apps/bff/docker-entrypoint.sh /usr/local/bin/bff-entrypoint.sh
+RUN chmod +x /usr/local/bin/bff-entrypoint.sh
 USER node
+EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=5 CMD \
   node -e "fetch('http://127.0.0.1:' + (process.env.PORT || '3000') + '/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 ENTRYPOINT ["bff-entrypoint.sh"]

--- a/apps/bff/src/app.module.ts
+++ b/apps/bff/src/app.module.ts
@@ -92,22 +92,15 @@ import { HealthController } from './health.controller';
           } satisfies DataSourceOptions;
         }
 
-        const isProduction = nodeEnv === 'production';
-        const host = isProduction
-          ? configService.getOrThrow<string>('POSTGRES_HOST')
-          : configService.get<string>('POSTGRES_HOST') ?? 'localhost';
-        const port = isProduction
-          ? Number(configService.getOrThrow<string>('POSTGRES_PORT'))
-          : Number(configService.get<string>('POSTGRES_PORT') ?? '5432');
-        const username = isProduction
-          ? configService.getOrThrow<string>('POSTGRES_USER')
-          : configService.get<string>('POSTGRES_USER') ?? 'paypay';
-        const password = isProduction
-          ? configService.getOrThrow<string>('POSTGRES_PASSWORD')
-          : configService.get<string>('POSTGRES_PASSWORD') ?? 'paypay';
-        const database = isProduction
-          ? configService.getOrThrow<string>('POSTGRES_DB')
-          : configService.get<string>('POSTGRES_DB') ?? 'paypay';
+        const host = configService.getOrThrow<string>('POSTGRES_HOST');
+        const portRaw = configService.getOrThrow<string>('POSTGRES_PORT');
+        const port = Number(portRaw);
+        if (Number.isNaN(port)) {
+          throw new Error('POSTGRES_PORT must be a valid number');
+        }
+        const username = configService.getOrThrow<string>('POSTGRES_USER');
+        const password = configService.getOrThrow<string>('POSTGRES_PASSWORD');
+        const database = configService.getOrThrow<string>('POSTGRES_DB');
 
         return {
           ...baseOptions,

--- a/apps/bff/src/database/data-source.ts
+++ b/apps/bff/src/database/data-source.ts
@@ -2,13 +2,26 @@ import 'reflect-metadata';
 import { DataSource } from 'typeorm';
 import * as path from 'path';
 
+const requireEnv = (key: string): string => {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`[database] Missing required environment variable: ${key}`);
+  }
+  return value;
+};
+
+const postgresPort = Number(requireEnv('POSTGRES_PORT'));
+if (Number.isNaN(postgresPort)) {
+  throw new Error('[database] POSTGRES_PORT must be a valid number');
+}
+
 export const AppDataSource = new DataSource({
   type: 'postgres',
-  host: process.env.POSTGRES_HOST || 'postgres',
-  port: Number(process.env.POSTGRES_PORT || 5432),
-  username: process.env.POSTGRES_USER || 'paypay',
-  password: process.env.POSTGRES_PASSWORD || 'paypay',
-  database: process.env.POSTGRES_DB || 'paypay',
+  host: requireEnv('POSTGRES_HOST'),
+  port: postgresPort,
+  username: requireEnv('POSTGRES_USER'),
+  password: requireEnv('POSTGRES_PASSWORD'),
+  database: requireEnv('POSTGRES_DB'),
   ssl: false,
   entities: [__dirname + '/../**/*.entity.{js,ts}'],
   migrations:

--- a/apps/bff/src/main.ts
+++ b/apps/bff/src/main.ts
@@ -123,7 +123,7 @@ async function bootstrap() {
     ]
   });
 
-  const port = env.PORT ?? 3000;
+  const port = Number(process.env.PORT ?? 3000);
   await app.listen(port, '0.0.0.0');
   logger.log(`🚀 BFF is running at http://0.0.0.0:${port}`);
 }

--- a/apps/bff/test/setup-env.ts
+++ b/apps/bff/test/setup-env.ts
@@ -1,17 +1,21 @@
+import { randomBytes } from 'crypto';
+
 process.env.NODE_ENV = 'test';
 process.env.DB_TYPE = process.env.DB_TYPE ?? 'sqlite';
 process.env.DB_DATABASE = process.env.DB_DATABASE ?? ':memory:';
-process.env.JWT_ACCESS_TOKEN_SECRET = process.env.JWT_ACCESS_TOKEN_SECRET ?? 'test-access-secret';
-process.env.JWT_REFRESH_TOKEN_SECRET = process.env.JWT_REFRESH_TOKEN_SECRET ?? 'test-refresh-secret';
-process.env.COOKIE_SECRET =
-  process.env.COOKIE_SECRET ?? 'test-cookie-secret-should-be-at-least-32-characters';
+
+const strongHex = (bytes: number) => randomBytes(bytes).toString('hex');
+const strongBase64 = (bytes: number) => randomBytes(bytes).toString('base64');
+
+process.env.JWT_ACCESS_TOKEN_SECRET = process.env.JWT_ACCESS_TOKEN_SECRET ?? strongHex(48);
+process.env.JWT_REFRESH_TOKEN_SECRET = process.env.JWT_REFRESH_TOKEN_SECRET ?? strongHex(48);
+process.env.COOKIE_SECRET = process.env.COOKIE_SECRET ?? strongHex(48);
 process.env.FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN ?? 'http://localhost:3000';
 process.env.PAYPAY_DOMAIN = process.env.PAYPAY_DOMAIN ?? 'paypay.test';
 process.env.PAYPAY_API_DOMAIN = process.env.PAYPAY_API_DOMAIN ?? 'api.paypay.test';
 process.env.BTCPAY_SERVER_URL = process.env.BTCPAY_SERVER_URL ?? 'https://btcpay.local';
-process.env.BTCPAY_ADMIN_API_KEY = process.env.BTCPAY_ADMIN_API_KEY ?? 'test-admin-api-key';
-process.env.BTCPAY_MASTER_KEY =
-  process.env.BTCPAY_MASTER_KEY ?? Buffer.from('0123456789abcdef0123456789abcdef').toString('base64');
+process.env.BTCPAY_ADMIN_API_KEY = process.env.BTCPAY_ADMIN_API_KEY ?? strongHex(32);
+process.env.BTCPAY_MASTER_KEY = process.env.BTCPAY_MASTER_KEY ?? strongBase64(48);
 process.env.BTCPAY_WEBHOOK_URL = process.env.BTCPAY_WEBHOOK_URL ?? 'https://api.local/hooks/btcpay';
 process.env.BTCPAY_HEALTH_STORE_ID = process.env.BTCPAY_HEALTH_STORE_ID ?? 'store-health';
-process.env.BTCPAY_HEALTH_API_KEY = process.env.BTCPAY_HEALTH_API_KEY ?? 'health-api-key';
+process.env.BTCPAY_HEALTH_API_KEY = process.env.BTCPAY_HEALTH_API_KEY ?? strongHex(32);


### PR DESCRIPTION
## Summary
- prevent dotenv files from reaching the BFF image and require Postgres settings from the runtime environment
- ensure the BFF binds on 0.0.0.0, keeps the health check start period, and documents the env inspection workflow
- replace test-time secret placeholders with strong random values to avoid leaking defaults

## Testing
- `docker compose down --remove-orphans` *(fails in CI: docker not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd687c17c0832fbf4c98b9b625a7f4