### PR TITLE
Add frontend health endpoint and Docker healthcheck improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ Internally, `up.sh` calls `./check-required-env.sh infra/env/.env` and then runs
 ## Health check
 - The BFF exposes `GET /health` and `GET /readyz`. After starting locally or via Docker, verify readiness with `curl http://localhost:3000/health`.
 
+### Frontend health endpoint
+The frontend ships with a lightweight `GET /health` endpoint to support Docker health probes. It returns `200 OK` with `{ "ok": true }` only if the Next.js process is running, without leaking secrets or touching external services.
+
+Check the endpoint manually inside the container:
+```
+docker compose exec frontend wget -qO- http://127.0.0.1:3000/health
+```
+Confirm the container status:
+```
+docker compose ps
+```
+The frontend service should report `running (healthy)` once the probe succeeds.
+
 ## Structure
 - `apps/frontend` – Next.js 15 App Router frontend with Tailwind CSS and shadcn/ui primitives.
 - `apps/bff` – NestJS BFF acting as a secure proxy/orchestrator for BTCPay Server integrations.

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -28,6 +28,6 @@ USER node
 EXPOSE 3000
 ENV PORT=3000
 ENV HOST=0.0.0.0
-HEALTHCHECK --interval=10s --timeout=3s --start-period=15s --retries=5 \
-  CMD node -e "const http=require('http');const req=http.request({hostname:'127.0.0.1',port:3000,path:'/health',timeout:2000},res=>process.exit(res.statusCode===200?0:1));req.on('error',()=>process.exit(1));req.end()"
+HEALTHCHECK --interval=30s --timeout=5s --retries=12 \
+  CMD node -e "fetch('http://127.0.0.1:' + (process.env.PORT || '3000') + '/health',{cache:'no-store'}).then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 CMD ["node", "apps/frontend/server.js"]

--- a/apps/frontend/app/health/route.ts
+++ b/apps/frontend/app/health/route.ts
@@ -1,3 +1,14 @@
-export function GET() {
-  return new Response('ok', { status: 200 });
+export const runtime = 'nodejs';
+
+export async function GET() {
+  // Minimal, safe response for Docker HEALTHCHECK
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+      pragma: 'no-cache',
+      expires: '0',
+    },
+  });
 }


### PR DESCRIPTION
## Summary
- add a Next.js `/health` route that returns a JSON payload with cache disabled for Docker probes
- document how to inspect the frontend health endpoint from Docker Compose
- update the frontend container healthcheck to poll `/health` via the built-in Node.js fetch API

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd6d3b3504832fa73bd79507eee3ed