### PR TITLE
Update frontend health checks to use node fetch

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -28,6 +28,7 @@ USER node
 EXPOSE 3000
 ENV PORT=3000
 ENV HOST=0.0.0.0
-HEALTHCHECK --interval=30s --timeout=5s --retries=12 \
+ENV HOSTNAME=0.0.0.0
+HEALTHCHECK --interval=30s --timeout=5s --retries=12 --start-period=15s \
   CMD node -e "fetch('http://127.0.0.1:' + (process.env.PORT || '3000') + '/health',{cache:'no-store'}).then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 CMD ["node", "apps/frontend/server.js"]

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -10,15 +10,17 @@ services:
     environment:
       - NEXT_PUBLIC_BFF_URL
       - NEXT_PUBLIC_API_BASE
+      - HOSTNAME=0.0.0.0
+      - PORT=3000
     depends_on:
       bff:
         condition: service_healthy
     healthcheck:
-      test: ['CMD-SHELL', 'wget -q -O- http://127.0.0.1:3000/health >/dev/null']
-      interval: 10s
-      timeout: 3s
+      test: ["CMD-SHELL", "node -e \"fetch('http://127.0.0.1:' + (process.env.PORT || '3000') + '/health',{cache:'no-store'}).then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      interval: 30s
+      timeout: 5s
       start_period: 15s
-      retries: 5
+      retries: 12
     networks:
       - paynet
 


### PR DESCRIPTION
## Summary
- add HOSTNAME env var and align healthcheck in the frontend Dockerfile
- expose HOSTNAME/PORT and switch docker-compose frontend healthcheck to node fetch

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd72036b8c832f85b1f5e2b2a9bd75