### PR TITLE
Remove redundant email normalization hook

### DIFF
--- a/apps/bff/src/auth/entities/user.entity.ts
+++ b/apps/bff/src/auth/entities/user.entity.ts
@@ -1,5 +1,4 @@
 import {
-  BeforeInsert,
   Column,
   CreateDateColumn,
   Entity,
@@ -8,7 +7,6 @@ import {
   UpdateDateColumn
 } from 'typeorm';
 import { RefreshTokenEntity } from './refresh-token.entity';
-import { normalizeEmail } from '../email.utils';
 
 @Entity({ name: 'users' })
 export class UserEntity {
@@ -30,8 +28,4 @@ export class UserEntity {
   @OneToMany(() => RefreshTokenEntity, (token) => token.user)
   refreshTokens!: RefreshTokenEntity[];
 
-  @BeforeInsert()
-  normalizeEmailBeforeInsert(): void {
-    this.email = normalizeEmail(this.email);
-  }
 }


### PR DESCRIPTION
## Summary
- remove the BeforeInsert normalization hook from UserEntity to rely on service-level normalization

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dda1c72b34832fb0aff1c533b631a9