### PR TITLE
chore: align throttling defaults with nest v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ You can also spin up the Docker stack locally with the same production instructi
 - Platform services:
   - `POSTGRES_*` or `DATABASE_URL`
   - `SMTP_*`
-  - `TRUST_PROXY` (override if your proxy chain differs)
+- `TRUST_PROXY` (defaults to `loopback`; override if your proxy chain differs)
   - `NODE_ENV=production`
 
 If your edge or proxy strips the `/api` prefix before reaching the BFF, configure `BTCPAY_WEBHOOK_URL` without `/api` and align the routing rules accordingly. By default, we use `https://$PAYPAY_API_DOMAIN/api/hooks/btcpay`.

--- a/apps/bff/src/app.module.ts
+++ b/apps/bff/src/app.module.ts
@@ -44,7 +44,7 @@ import { HealthController } from './health.controller';
         }
       }
     }),
-    ThrottlerModule.forRoot([{ ttl: 60, limit: 5 }]),
+    ThrottlerModule.forRoot([{ ttl: 60_000, limit: 5 }]),
     TypeOrmModule.forRootAsync({
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {

--- a/apps/bff/src/config/env.validation.ts
+++ b/apps/bff/src/config/env.validation.ts
@@ -12,7 +12,7 @@ const base64Min32 = z.string().refine((val) => {
 export const EnvSchema = z.object({
   NODE_ENV: z.string().default('production'),
   PORT: z.coerce.number().default(3000),
-  TRUST_PROXY: z.coerce.number().default(1),
+  TRUST_PROXY: z.union([z.coerce.number(), z.string()]).default('loopback'),
 
   COOKIE_SECRET: z.string().min(32, 'must be at least 32 chars or Base64'),
   JWT_ACCESS_TOKEN_SECRET: z.string().min(32),

--- a/apps/bff/src/main.ts
+++ b/apps/bff/src/main.ts
@@ -14,7 +14,7 @@ import { getEnv } from './config/env.validation';
 
 function parseTrustProxy(v?: string | number | boolean): any {
   if (v === undefined) {
-    return 1;
+    return 'loopback';
   }
   if (typeof v === 'number') {
     return v;
@@ -24,11 +24,12 @@ function parseTrustProxy(v?: string | number | boolean): any {
   }
   const normalized = v.trim();
   if (normalized === '') {
-    return 1;
+    return 'loopback';
   }
   const lower = normalized.toLowerCase();
   if (lower === 'false' || lower === '0') return false;
   if (lower === 'true') return true;
+  if (lower === 'loopback') return 'loopback';
   const num = Number(normalized);
   return Number.isNaN(num) ? normalized : num;
 }
@@ -64,7 +65,7 @@ async function bootstrap() {
   const trustProxyValue = parseTrustProxy(env.TRUST_PROXY);
 
   if (type === 'fastify') {
-    (instance as any).trustProxy = trustProxyValue;
+    (instance as any).trustProxy = trustProxyValue ?? 'loopback';
     // TODO: Provide a raw body hook for BTCPay webhooks if we migrate to the Fastify adapter.
   }
 
@@ -73,9 +74,10 @@ async function bootstrap() {
       use: (path: any, ...handlers: any[]) => void;
       set: (setting: string, value: any) => void;
     };
-    const effectiveTrustProxyValue = trustProxyValue === false ? 1 : trustProxyValue;
+    const effectiveTrustProxyValue =
+      trustProxyValue === undefined || trustProxyValue === null ? 'loopback' : trustProxyValue;
     // Ensure IP forwarding works correctly when running behind a layer 7 proxy.
-    expressInstance.set('trust proxy', effectiveTrustProxyValue ?? 1);
+    expressInstance.set('trust proxy', effectiveTrustProxyValue);
 
     const hooksPaths = ['/hooks/btcpay', '/api/hooks/btcpay'];
     const isBtcpayHookPath = (path: string) =>

--- a/apps/bff/src/tenants/tenants.controller.ts
+++ b/apps/bff/src/tenants/tenants.controller.ts
@@ -61,7 +61,8 @@ export class TenantsController {
   }
 
   @Post(':tenantId/apikey/rotate')
-  @Throttle(3, 60)
+  // NestJS v6+: object-based syntax; ttl uses milliseconds (60 seconds)
+  @Throttle({ default: { limit: 3, ttl: 60_000 } })
   rotateApiKey(
     @Param('tenantId', ParseUUIDPipe) tenantId: string,
     @Query() query: RotateApiKeyQueryDto,
@@ -73,7 +74,7 @@ export class TenantsController {
   }
 
   @Delete(':tenantId/stores/:storeId')
-  @Throttle(3, 60)
+  @Throttle({ default: { limit: 3, ttl: 60_000 } })
   deleteStore(
     @Param('tenantId', ParseUUIDPipe) tenantId: string,
     @Param('storeId', ParseUUIDPipe) storeId: string,

--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -1,7 +1,7 @@
 # Copy to infra/env/.env and fill in. Do NOT commit real secrets.
 NODE_ENV=production
 PORT=3000
-TRUST_PROXY=1
+TRUST_PROXY=loopback
 FRONTEND_ORIGIN=https://paypay.iddqd.in
 COOKIE_SECRET=base64-32-bytes
 JWT_ACCESS_TOKEN_SECRET=base64-32-bytes


### PR DESCRIPTION
## Summary
- update the BFF ThrottlerModule configuration to use millisecond TTLs expected by NestJS v6
- relax environment parsing so TRUST_PROXY defaults to the recommended `loopback` value and document the change
- ensure the runtime bootstrap sets `trust proxy` to `loopback` when not explicitly overridden

## Testing
- pnpm --filter bff build

------
https://chatgpt.com/codex/tasks/task_e_68de710ba54c832fb6686eee9a18a36a