### PR TITLE
fix: explicit TypeORM column types + migration + reflect-metadata

### DIFF
--- a/apps/bff/src/auth/entities/refresh-token.entity.ts
+++ b/apps/bff/src/auth/entities/refresh-token.entity.ts
@@ -1,8 +1,6 @@
 import { Column, CreateDateColumn, Entity, Index, JoinColumn, ManyToOne, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+import { TIMESTAMP_COLUMN_TYPE } from '../../database/utils/column-types';
 import { UserEntity } from './user.entity';
-
-const dateColumnType =
-  process.env.DB_TYPE === 'sqlite' || process.env.NODE_ENV === 'test' ? 'datetime' : 'timestamptz';
 
 @Entity({ name: 'refresh_tokens' })
 export class RefreshTokenEntity {
@@ -17,18 +15,18 @@ export class RefreshTokenEntity {
   @JoinColumn({ name: 'user_id' })
   user?: UserEntity;
 
-  @Column({ name: 'token_hash' })
+  @Column({ name: 'token_hash', type: 'varchar', length: 255 })
   tokenHash!: string;
 
-  @Column({ name: 'expires_at', type: dateColumnType })
+  @Column({ name: 'expires_at', type: TIMESTAMP_COLUMN_TYPE })
   expiresAt!: Date;
 
-  @Column({ name: 'revoked_at', type: dateColumnType, nullable: true })
+  @Column({ name: 'revoked_at', type: TIMESTAMP_COLUMN_TYPE, nullable: true })
   revokedAt!: Date | null;
 
-  @CreateDateColumn({ name: 'created_at' })
+  @CreateDateColumn({ name: 'created_at', type: TIMESTAMP_COLUMN_TYPE })
   createdAt!: Date;
 
-  @UpdateDateColumn({ name: 'updated_at' })
+  @UpdateDateColumn({ name: 'updated_at', type: TIMESTAMP_COLUMN_TYPE })
   updatedAt!: Date;
 }

--- a/apps/bff/src/auth/entities/user.entity.ts
+++ b/apps/bff/src/auth/entities/user.entity.ts
@@ -6,6 +6,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn
 } from 'typeorm';
+import { TIMESTAMP_COLUMN_TYPE } from '../../database/utils/column-types';
 import { RefreshTokenEntity } from './refresh-token.entity';
 
 @Entity({ name: 'users' })
@@ -16,13 +17,13 @@ export class UserEntity {
   @Column({ type: 'varchar', length: 320, unique: true })
   email!: string;
 
-  @Column({ name: 'password_hash' })
+  @Column({ name: 'password_hash', type: 'varchar', length: 255 })
   passwordHash!: string;
 
-  @CreateDateColumn({ name: 'created_at' })
+  @CreateDateColumn({ name: 'created_at', type: TIMESTAMP_COLUMN_TYPE })
   createdAt!: Date;
 
-  @UpdateDateColumn({ name: 'updated_at' })
+  @UpdateDateColumn({ name: 'updated_at', type: TIMESTAMP_COLUMN_TYPE })
   updatedAt!: Date;
 
   @OneToMany(() => RefreshTokenEntity, (token) => token.user)

--- a/apps/bff/src/database/utils/column-types.ts
+++ b/apps/bff/src/database/utils/column-types.ts
@@ -1,0 +1,2 @@
+export const TIMESTAMP_COLUMN_TYPE =
+  process.env.DB_TYPE === 'sqlite' || process.env.NODE_ENV === 'test' ? 'datetime' : 'timestamptz';

--- a/apps/bff/src/migrations/1728400000000-ExplicitColumnTypes.ts
+++ b/apps/bff/src/migrations/1728400000000-ExplicitColumnTypes.ts
@@ -1,0 +1,141 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ExplicitColumnTypes1728400000000 implements MigrationInterface {
+  name = 'ExplicitColumnTypes1728400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "users" ALTER COLUMN "email" TYPE varchar(320) USING LEFT("email", 320)'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "users" ALTER COLUMN "password_hash" TYPE varchar(255) USING LEFT("password_hash", 255)'
+    );
+
+    await queryRunner.query(
+      'ALTER TABLE "refresh_tokens" ALTER COLUMN "token_hash" TYPE varchar(255) USING LEFT("token_hash", 255)'
+    );
+
+    await queryRunner.query(
+      'ALTER TABLE "tenants" ALTER COLUMN "email" TYPE varchar(320) USING LEFT("email", 320)'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "tenants" ALTER COLUMN "name" TYPE varchar(160) USING LEFT("name", 160)'
+    );
+
+    await queryRunner.query(
+      'ALTER TABLE "stores" ALTER COLUMN "btcpay_host" TYPE varchar(320) USING LEFT("btcpay_host", 320)'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "stores" ALTER COLUMN "btcpay_store_id" TYPE varchar(160) USING LEFT("btcpay_store_id", 160)'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "stores" ALTER COLUMN "store_name" TYPE varchar(160) USING LEFT("store_name", 160)'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "stores" ALTER COLUMN "store_website" TYPE varchar(2048)'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "stores" ALTER COLUMN "webhook_id" TYPE varchar(160) USING LEFT("webhook_id", 160)'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "stores" ALTER COLUMN "wallet_setup_status" TYPE varchar(32) USING LEFT("wallet_setup_status", 32)'
+    );
+    await queryRunner.query(
+      "ALTER TABLE \"stores\" ALTER COLUMN \"wallet_setup_status\" SET DEFAULT 'pending'"
+    );
+
+    await queryRunner.query(
+      'ALTER TABLE "audit_logs" ALTER COLUMN "actor_id" TYPE varchar(160) USING LEFT("actor_id", 160)'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "audit_logs" ALTER COLUMN "action" TYPE varchar(160) USING LEFT("action", 160)'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "audit_logs" ALTER COLUMN "resource" TYPE varchar(160) USING LEFT("resource", 160)'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "audit_logs" ALTER COLUMN "result" TYPE varchar(32) USING LEFT("result", 32)'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "audit_logs" ALTER COLUMN "ip" TYPE varchar(64) USING LEFT("ip", 64)'
+    );
+
+    await queryRunner.query(
+      'ALTER TABLE "idempotency_keys" ALTER COLUMN "key" TYPE varchar(200) USING LEFT("key", 200)'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "idempotency_keys" ALTER COLUMN "source" TYPE varchar(160) USING LEFT("source", 160)'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "idempotency_keys" ALTER COLUMN "resource_id" TYPE varchar(160) USING LEFT("resource_id", 160)'
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "idempotency_keys" ALTER COLUMN "resource_id" TYPE varchar USING "resource_id"::varchar'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "idempotency_keys" ALTER COLUMN "source" TYPE varchar USING "source"::varchar'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "idempotency_keys" ALTER COLUMN "key" TYPE varchar USING "key"::varchar'
+    );
+
+    await queryRunner.query(
+      'ALTER TABLE "audit_logs" ALTER COLUMN "ip" TYPE varchar USING "ip"::varchar'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "audit_logs" ALTER COLUMN "result" TYPE varchar USING "result"::varchar'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "audit_logs" ALTER COLUMN "resource" TYPE varchar USING "resource"::varchar'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "audit_logs" ALTER COLUMN "action" TYPE varchar USING "action"::varchar'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "audit_logs" ALTER COLUMN "actor_id" TYPE varchar USING "actor_id"::varchar'
+    );
+
+    await queryRunner.query(
+      'ALTER TABLE "stores" ALTER COLUMN "wallet_setup_status" TYPE varchar USING "wallet_setup_status"::varchar'
+    );
+    await queryRunner.query(
+      "ALTER TABLE \"stores\" ALTER COLUMN \"wallet_setup_status\" SET DEFAULT 'pending'"
+    );
+    await queryRunner.query(
+      'ALTER TABLE "stores" ALTER COLUMN "webhook_id" TYPE varchar USING "webhook_id"::varchar'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "stores" ALTER COLUMN "store_website" TYPE varchar(512) USING LEFT("store_website", 512)'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "stores" ALTER COLUMN "store_name" TYPE varchar(255) USING LEFT("store_name", 255)'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "stores" ALTER COLUMN "btcpay_store_id" TYPE varchar USING "btcpay_store_id"::varchar'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "stores" ALTER COLUMN "btcpay_host" TYPE varchar USING "btcpay_host"::varchar'
+    );
+
+    await queryRunner.query(
+      'ALTER TABLE "tenants" ALTER COLUMN "name" TYPE varchar USING "name"::varchar'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "tenants" ALTER COLUMN "email" TYPE varchar USING "email"::varchar'
+    );
+
+    await queryRunner.query(
+      'ALTER TABLE "refresh_tokens" ALTER COLUMN "token_hash" TYPE text USING "token_hash"::text'
+    );
+
+    await queryRunner.query(
+      'ALTER TABLE "users" ALTER COLUMN "password_hash" TYPE text USING "password_hash"::text'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "users" ALTER COLUMN "email" TYPE text USING "email"::text'
+    );
+  }
+}

--- a/apps/bff/src/tenants/entities/audit-log.entity.ts
+++ b/apps/bff/src/tenants/entities/audit-log.entity.ts
@@ -1,4 +1,5 @@
 import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { TIMESTAMP_COLUMN_TYPE } from '../../database/utils/column-types';
 import { TenantEntity } from './tenant.entity';
 
 @Entity({ name: 'audit_logs' })
@@ -10,24 +11,24 @@ export class AuditLogEntity {
   @JoinColumn({ name: 'tenant_id' })
   tenant!: TenantEntity;
 
-  @Column({ name: 'tenant_id' })
+  @Column({ name: 'tenant_id', type: 'uuid' })
   tenantId!: string;
 
-  @Column({ name: 'actor_id', nullable: true, type: 'varchar' })
+  @Column({ name: 'actor_id', type: 'varchar', length: 160, nullable: true })
   actorId: string | null = null;
 
-  @Column()
+  @Column({ type: 'varchar', length: 160 })
   action!: string;
 
-  @Column()
+  @Column({ type: 'varchar', length: 160 })
   resource!: string;
 
-  @Column()
+  @Column({ type: 'varchar', length: 32 })
   result!: string;
 
-  @Column({ nullable: true, type: 'varchar' })
+  @Column({ nullable: true, type: 'varchar', length: 64 })
   ip!: string | null;
 
-  @CreateDateColumn({ name: 'ts' })
+  @CreateDateColumn({ name: 'ts', type: TIMESTAMP_COLUMN_TYPE })
   timestamp!: Date;
 }

--- a/apps/bff/src/tenants/entities/idempotency-key.entity.ts
+++ b/apps/bff/src/tenants/entities/idempotency-key.entity.ts
@@ -1,19 +1,20 @@
 import { Column, CreateDateColumn, Entity, PrimaryColumn } from 'typeorm';
+import { TIMESTAMP_COLUMN_TYPE } from '../../database/utils/column-types';
 
 @Entity({ name: 'idempotency_keys' })
 export class IdempotencyKeyEntity {
-  @PrimaryColumn()
+  @PrimaryColumn({ type: 'varchar', length: 200 })
   key!: string;
 
-  @Column({ name: 'tenant_id', nullable: true, type: 'varchar' })
+  @Column({ name: 'tenant_id', type: 'uuid', nullable: true })
   tenantId!: string | null;
 
-  @Column()
+  @Column({ type: 'varchar', length: 160 })
   source!: string;
 
-  @Column({ name: 'resource_id', nullable: true, type: 'varchar' })
+  @Column({ name: 'resource_id', type: 'varchar', length: 160, nullable: true })
   resourceId!: string | null;
 
-  @CreateDateColumn({ name: 'ts' })
+  @CreateDateColumn({ name: 'ts', type: TIMESTAMP_COLUMN_TYPE })
   timestamp!: Date;
 }

--- a/apps/bff/src/tenants/entities/store.entity.ts
+++ b/apps/bff/src/tenants/entities/store.entity.ts
@@ -7,6 +7,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn
 } from 'typeorm';
+import { TIMESTAMP_COLUMN_TYPE } from '../../database/utils/column-types';
 import { TenantEntity } from './tenant.entity';
 
 @Entity({ name: 'stores' })
@@ -18,22 +19,22 @@ export class StoreEntity {
   @JoinColumn({ name: 'tenant_id' })
   tenant!: TenantEntity;
 
-  @Column({ name: 'tenant_id' })
+  @Column({ name: 'tenant_id', type: 'uuid' })
   tenantId!: string;
 
-  @Column({ name: 'btcpay_host' })
+  @Column({ name: 'btcpay_host', type: 'varchar', length: 320 })
   btcpayHost!: string;
 
-  @Column({ name: 'btcpay_store_id' })
+  @Column({ name: 'btcpay_store_id', type: 'varchar', length: 160 })
   btcpayStoreId!: string;
 
-  @Column({ name: 'store_name', nullable: true })
+  @Column({ name: 'store_name', type: 'varchar', length: 160, nullable: true })
   storeName!: string | null;
 
-  @Column({ name: 'store_website', nullable: true })
+  @Column({ name: 'store_website', type: 'varchar', length: 2048, nullable: true })
   storeWebsite!: string | null;
 
-  @Column({ name: 'store_key_last_four', nullable: true, length: 4 })
+  @Column({ name: 'store_key_last_four', type: 'varchar', nullable: true, length: 4 })
   storeKeyLastFour!: string | null;
 
   @Column({ name: 'api_key_ciphertext', type: 'text' })
@@ -42,7 +43,7 @@ export class StoreEntity {
   @Column({ name: 'api_key_dek_wrapped', type: 'text' })
   apiKeyDekWrapped!: string;
 
-  @Column({ name: 'webhook_id' })
+  @Column({ name: 'webhook_id', type: 'varchar', length: 160 })
   webhookId!: string;
 
   @Column({ name: 'webhook_secret_ciphertext', type: 'text' })
@@ -51,12 +52,12 @@ export class StoreEntity {
   @Column({ name: 'webhook_secret_dek_wrapped', type: 'text' })
   webhookSecretDekWrapped!: string;
 
-  @Column({ name: 'wallet_setup_status', default: 'pending' })
+  @Column({ name: 'wallet_setup_status', type: 'varchar', length: 32, default: 'pending' })
   walletSetupStatus!: string;
 
-  @CreateDateColumn({ name: 'created_at' })
+  @CreateDateColumn({ name: 'created_at', type: TIMESTAMP_COLUMN_TYPE })
   createdAt!: Date;
 
-  @UpdateDateColumn({ name: 'updated_at' })
+  @UpdateDateColumn({ name: 'updated_at', type: TIMESTAMP_COLUMN_TYPE })
   updatedAt!: Date;
 }

--- a/apps/bff/src/tenants/entities/tenant.entity.ts
+++ b/apps/bff/src/tenants/entities/tenant.entity.ts
@@ -6,6 +6,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn
 } from 'typeorm';
+import { TIMESTAMP_COLUMN_TYPE } from '../../database/utils/column-types';
 import { StoreEntity } from './store.entity';
 import { AuditLogEntity } from './audit-log.entity';
 
@@ -14,16 +15,16 @@ export class TenantEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
-  @Column({ unique: true })
+  @Column({ type: 'varchar', length: 320, unique: true })
   email!: string;
 
-  @Column()
+  @Column({ type: 'varchar', length: 160 })
   name!: string;
 
-  @CreateDateColumn({ name: 'created_at' })
+  @CreateDateColumn({ name: 'created_at', type: TIMESTAMP_COLUMN_TYPE })
   createdAt!: Date;
 
-  @UpdateDateColumn({ name: 'updated_at' })
+  @UpdateDateColumn({ name: 'updated_at', type: TIMESTAMP_COLUMN_TYPE })
   updatedAt!: Date;
 
   @OneToMany(() => StoreEntity, (store) => store.tenant)

--- a/apps/bff/test/database/data-source.spec.ts
+++ b/apps/bff/test/database/data-source.spec.ts
@@ -1,0 +1,37 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import { UserEntity } from '../../src/auth/entities/user.entity';
+import { RefreshTokenEntity } from '../../src/auth/entities/refresh-token.entity';
+import { TenantEntity } from '../../src/tenants/entities/tenant.entity';
+import { StoreEntity } from '../../src/tenants/entities/store.entity';
+import { AuditLogEntity } from '../../src/tenants/entities/audit-log.entity';
+import { IdempotencyKeyEntity } from '../../src/tenants/entities/idempotency-key.entity';
+
+describe('Database schema', () => {
+  it('initializes an in-memory sqlite DataSource without unsupported types', async () => {
+    const dataSource = new DataSource({
+      type: 'sqlite',
+      database: ':memory:',
+      entities: [
+        UserEntity,
+        RefreshTokenEntity,
+        TenantEntity,
+        StoreEntity,
+        AuditLogEntity,
+        IdempotencyKeyEntity
+      ],
+      synchronize: true,
+      dropSchema: true,
+      logging: false
+    });
+
+    try {
+      const connection = await dataSource.initialize();
+      expect(connection.isInitialized).toBe(true);
+    } finally {
+      if (dataSource.isInitialized) {
+        await dataSource.destroy();
+      }
+    }
+  });
+});

--- a/apps/bff/test/health.e2e-spec.ts
+++ b/apps/bff/test/health.e2e-spec.ts
@@ -1,0 +1,38 @@
+import { INestApplication, RequestMethod, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('HealthController (e2e)', () => {
+  let app: INestApplication;
+  let server: any;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule]
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: false, forbidNonWhitelisted: true })
+    );
+    app.setGlobalPrefix('api', {
+      exclude: [
+        { path: 'health', method: RequestMethod.ALL },
+        { path: 'healthz', method: RequestMethod.ALL },
+        { path: 'readyz', method: RequestMethod.ALL }
+      ]
+    });
+    await app.init();
+    server = app.getHttpServer();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns a lightweight liveness response', async () => {
+    const response = await request(server).get('/health').expect(200);
+    expect(response.body).toEqual({ status: 'ok' });
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared TIMESTAMP_COLUMN_TYPE helper and annotate BFF entities with explicit varchar/json/timestamptz column metadata
- create a schema migration to align Postgres column definitions with the new entity constraints
- cover the DataSource bootstrap and /health probe with automated Jest tests to guard against regressions

## Testing
- pnpm --filter bff exec jest --runInBand
- pnpm typecheck (fails in unrelated workspaces)
- pnpm lint (fails in unrelated workspaces)

## Deployment
- Run the new TypeORM migration (apps/bff/src/migrations/1728400000000-ExplicitColumnTypes.ts); the migrate.ts script already executes on container startup.

------
https://chatgpt.com/codex/tasks/task_e_68de7d352228832fb0f60e5393f2124d