### PR TITLE
Fix BFF build errors

### DIFF
--- a/apps/bff/package.json
+++ b/apps/bff/package.json
@@ -18,7 +18,6 @@
     "@paypay/sdk": "workspace:*",
     "argon2": "^0.41.1",
     "axios": "^1.7.7",
-    "bcryptjs": "^3.0.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "cookie-parser": "^1.4.7",

--- a/apps/bff/src/app.module.ts
+++ b/apps/bff/src/app.module.ts
@@ -17,6 +17,7 @@ import { IdempotencyKeyEntity } from './tenants/entities/idempotency-key.entity'
 import { TenantsModule } from './tenants/tenants.module';
 import { HooksModule } from './hooks/hooks.module';
 import { HealthController } from './health.controller';
+import type { IncomingMessage, ServerResponse } from 'http';
 
 @Module({
   imports: [
@@ -60,11 +61,13 @@ import { HealthController } from './health.controller';
           }
           return 'info';
         },
-        customLogObject: (req, res, val) => ({
+        customProps: (
+          req: IncomingMessage & { originalUrl?: string | undefined },
+          res: ServerResponse<IncomingMessage>
+        ) => ({
           statusCode: res.statusCode,
-          method: req.method,
-          path: req.originalUrl ?? req.url,
-          responseTime: val.responseTime
+          method: req.method ?? 'UNKNOWN',
+          path: req.originalUrl ?? req.url ?? 'UNKNOWN'
         })
       }
     }),

--- a/apps/bff/src/auth/auth.controller.ts
+++ b/apps/bff/src/auth/auth.controller.ts
@@ -10,7 +10,7 @@ import {
   UnauthorizedException
 } from '@nestjs/common';
 import { SkipThrottle, Throttle } from '@nestjs/throttler';
-import type { Response } from 'express';
+import type { CookieOptions, Response } from 'express';
 import { ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { SignupDto } from './dto/signup.dto';
@@ -31,8 +31,8 @@ import { RegisterDto } from './dto/register.dto';
 
 @Controller('auth')
 export class AuthController {
-  private readonly accessCookieOptions: Parameters<Response['cookie']>[2];
-  private readonly refreshCookieOptions: Parameters<Response['cookie']>[2];
+  private readonly accessCookieOptions: CookieOptions;
+  private readonly refreshCookieOptions: CookieOptions;
 
   constructor(
     private readonly authService: AuthService,

--- a/apps/bff/src/auth/auth.service.ts
+++ b/apps/bff/src/auth/auth.service.ts
@@ -15,7 +15,6 @@ import { UserEntity } from './entities/user.entity';
 import { RefreshTokenEntity } from './entities/refresh-token.entity';
 import { RegisterDto } from './dto/register.dto';
 import { normalizeEmail } from './email.utils';
-import * as bcrypt from 'bcryptjs';
 import { BtcpayProvisioningService } from '../btcpay/btcpay-provisioning.service';
 
 interface RefreshTokenPayload {
@@ -81,7 +80,7 @@ export class AuthService {
       user.btcpayUserId = btcpayUser?.id ?? user.btcpayUserId ?? null;
       user.btcpayApiKeyLabel = apiKey.label;
       user.btcpayApiKeyPermissions = JSON.stringify([...apiKey.permissions].sort());
-      user.btcpayApiKeyHash = await bcrypt.hash(apiKey.apiKey, 12);
+      user.btcpayApiKeyHash = await argon2.hash(apiKey.apiKey, { type: argon2.argon2id });
       await this.usersRepository.save(user);
 
       const tokens = await this.issueTokens(user, true);

--- a/apps/bff/test/auth.signup-provisioning.e2e-spec.ts
+++ b/apps/bff/test/auth.signup-provisioning.e2e-spec.ts
@@ -5,7 +5,7 @@ import request from 'supertest';
 import type { Response } from 'supertest';
 import nock from 'nock';
 import { DataSource } from 'typeorm';
-import * as bcrypt from 'bcryptjs';
+import * as argon2 from 'argon2';
 import { AppModule } from '../src/app.module';
 import { ACCESS_TOKEN_COOKIE_NAME, REFRESH_TOKEN_COOKIE_NAME } from '../src/auth/auth.constants';
 import { BTCPAY_PORTAL_USER_PERMISSIONS } from '../src/btcpay/btcpay.constants';
@@ -122,6 +122,6 @@ describe('Auth signup provisioning (e2e)', () => {
     expect(savedUser.btcpayApiKeyPermissions).toEqual(
       JSON.stringify([...BTCPAY_PORTAL_USER_PERMISSIONS].sort())
     );
-    expect(await bcrypt.compare('btcpay-api-key', savedUser.btcpayApiKeyHash!)).toBe(true);
+    expect(await argon2.verify(savedUser.btcpayApiKeyHash!, 'btcpay-api-key')).toBe(true);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       axios:
         specifier: ^1.7.7
         version: 1.12.2
-      bcryptjs:
-        specifier: ^3.0.2
-        version: 3.0.2
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -2094,10 +2091,6 @@ packages:
 
   baseline-browser-mapping@2.8.7:
     resolution: {integrity: sha512-bxxN2M3a4d1CRoQC//IqsR5XrLh0IJ8TCv2x6Y9N0nckNz/rTjZB3//GGscZziZOxmjP55rzxg/ze7usFI9FqQ==}
-    hasBin: true
-
-  bcryptjs@3.0.2:
-    resolution: {integrity: sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==}
     hasBin: true
 
   binary-extensions@2.3.0:
@@ -7428,8 +7421,6 @@ snapshots:
 
   baseline-browser-mapping@2.8.7: {}
 
-  bcryptjs@3.0.2: {}
-
   binary-extensions@2.3.0: {}
 
   bindings@1.5.0:
@@ -8058,7 +8049,7 @@ snapshots:
       '@typescript-eslint/parser': 8.45.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)
       eslint: 9.36.0(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint@9.36.0(jiti@1.21.7)))(eslint@9.36.0(jiti@1.21.7))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@1.21.7))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.36.0(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.36.0(jiti@1.21.7))
@@ -8082,7 +8073,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint@9.36.0(jiti@1.21.7)))(eslint@9.36.0(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@10.2.2)
@@ -8097,14 +8088,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@1.21.7)))(eslint@9.36.0(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint@9.36.0(jiti@1.21.7)))(eslint@9.36.0(jiti@1.21.7)))(eslint@9.36.0(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.45.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)
       eslint: 9.36.0(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint@9.36.0(jiti@1.21.7)))(eslint@9.36.0(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -8119,7 +8110,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.36.0(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@1.21.7)))(eslint@9.36.0(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint@9.36.0(jiti@1.21.7)))(eslint@9.36.0(jiti@1.21.7)))(eslint@9.36.0(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
- align the NestJS logger configuration with supported pino-http options and proper typings
- type cookie configuration explicitly and reuse argon2 for BTCPay API key hashing while updating tests
- remove the unused bcryptjs dependency from the workspace lockfile

## Testing
- pnpm --filter ./apps/bff... build

------
https://chatgpt.com/codex/tasks/task_e_68dfe8470ff4832f981ad4e4b58d6575