### PR TITLE
Provision BTCPay users without invitations

### DIFF
--- a/apps/bff/src/auth/auth.service.ts
+++ b/apps/bff/src/auth/auth.service.ts
@@ -70,7 +70,7 @@ export class AuthService {
     const user = await this.register(dto);
 
     try {
-      const btcpayUser = await this.btcpayProvisioning.createUserInBtcpay(user.email);
+      const btcpayUser = await this.btcpayProvisioning.createUserInBtcpay(user.email, dto.password);
       const apiKey = await this.btcpayProvisioning.createUserApiKey(
         user.email,
         'PayPay Portal',

--- a/apps/bff/src/btcpay/btcpay-provisioning.service.ts
+++ b/apps/bff/src/btcpay/btcpay-provisioning.service.ts
@@ -9,7 +9,7 @@ import {
   UnauthorizedException
 } from '@nestjs/common';
 import axios, { AxiosError, AxiosInstance } from 'axios';
-import { randomBytes, randomUUID } from 'crypto';
+import { randomUUID } from 'crypto';
 import { BTCPAY_PORTAL_USER_PERMISSIONS } from './btcpay.constants';
 import { BTCPAY_CONFIG, type BtcpayRuntimeConfig } from './btcpay.tokens';
 
@@ -30,9 +30,8 @@ export class BtcpayProvisioningService {
 
   constructor(@Inject(BTCPAY_CONFIG) private readonly config: BtcpayRuntimeConfig) {}
 
-  async createUserInBtcpay(email: string, password?: string): Promise<CreateUserResponse | null> {
-    const resolvedPassword = password ?? this.generatePassword();
-    const payload = { email, password: resolvedPassword };
+  async createUserInBtcpay(email: string, password: string): Promise<CreateUserResponse | null> {
+    const payload = { email, password, sendInvitationEmail: false };
 
     return this.performRequest<CreateUserResponse | null>({
       operation: 'create-user',
@@ -81,10 +80,6 @@ export class BtcpayProvisioningService {
 
   getDefaultPermissions(): readonly string[] {
     return BTCPAY_PORTAL_USER_PERMISSIONS;
-  }
-
-  private generatePassword(): string {
-    return randomBytes(48).toString('base64url');
   }
 
   private createHttp(): AxiosInstance {

--- a/apps/bff/test/auth.e2e-spec.ts
+++ b/apps/bff/test/auth.e2e-spec.ts
@@ -100,13 +100,15 @@ describe('AuthModule (e2e)', () => {
     const apiBasePath = btcpayUrl.pathname.replace(/\/$/, '');
     const adminToken = process.env.BTCPAY_ADMIN_API_KEY ?? 'admin-token';
     const signupEmail = 'second@example.com';
+    const signupPassword = 'averysecurepassword';
 
     const scope = nock(btcpayUrl.origin)
       .post(`${apiBasePath}/api/v1/users`, (body: any) => {
         expect(body).toEqual(
           expect.objectContaining({
             email: signupEmail,
-            password: expect.any(String)
+            password: signupPassword,
+            sendInvitationEmail: false
           })
         );
         return true;
@@ -129,7 +131,7 @@ describe('AuthModule (e2e)', () => {
     const signupResponse = await agent
       .post('/api/auth/signup')
       .set('X-CSRF-Token', signupCsrf)
-      .send({ email: signupEmail, password: 'averysecurepassword' })
+      .send({ email: signupEmail, password: signupPassword })
       .expect(201);
 
     expect(scope.isDone()).toBe(true);

--- a/apps/bff/test/auth.signup-provisioning.e2e-spec.ts
+++ b/apps/bff/test/auth.signup-provisioning.e2e-spec.ts
@@ -78,7 +78,8 @@ describe('Auth signup provisioning (e2e)', () => {
         expect(body).toEqual(
           expect.objectContaining({
             email,
-            password: expect.any(String)
+            password,
+            sendInvitationEmail: false
           })
         );
         return true;


### PR DESCRIPTION
## Summary
- provision BTCPay users with the password chosen during signup and skip invitation emails
- update the authentication e2e tests to assert the new provisioning payload

## Testing
- pnpm --filter bff exec jest

------
https://chatgpt.com/codex/tasks/task_e_68dff77356f0832fbb362f0d658988d2