### PR TITLE
Fix BTCPay signup to activate user invitations

### DIFF
--- a/apps/bff/src/btcpay/btcpay-provisioning.service.ts
+++ b/apps/bff/src/btcpay/btcpay-provisioning.service.ts
@@ -38,6 +38,7 @@ export class BtcpayProvisioningService {
       code: 'INTEGRATION_BTCPAY_CREATE_USER_FAILED',
       handler: async (http) => {
         const { data } = await http.post<CreateUserResponse>('/api/v1/users', payload);
+        await this.finalizeInvitationIfPresent(email);
         return data;
       },
       recover: (error) => {
@@ -80,6 +81,57 @@ export class BtcpayProvisioningService {
 
   getDefaultPermissions(): readonly string[] {
     return BTCPAY_PORTAL_USER_PERMISSIONS;
+  }
+
+  private normalizeInvitationUrl(rawUrl: string): string | undefined {
+    if (!rawUrl) {
+      return undefined;
+    }
+    try {
+      const trimmed = rawUrl.trim();
+      if (!trimmed) {
+        return undefined;
+      }
+      const url = new URL(trimmed, this.config.baseUrl);
+      return url.toString();
+    } catch (error) {
+      this.logger.warn(`Invalid BTCPay invitation URL received: ${rawUrl}`);
+      return undefined;
+    }
+  }
+
+  private async finalizeInvitationIfPresent(email: string): Promise<void> {
+    try {
+      const http = this.createHttp();
+      const encodedEmail = encodeURIComponent(email);
+      const { data } = await http.get<{ invitationUrl?: string | null }>(`/api/v1/users/${encodedEmail}`);
+      const invitationUrl = this.normalizeInvitationUrl(data?.invitationUrl ?? '');
+      if (!invitationUrl) {
+        return;
+      }
+
+      try {
+        await axios.get(invitationUrl, {
+          headers: {
+            Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'User-Agent': 'PayPay-BFF/1.0'
+          },
+          maxRedirects: 0,
+          validateStatus: (status) => status >= 200 && status < 400
+        });
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response && error.response.status >= 400 && error.response.status < 500) {
+          this.logger.warn(
+            `BTCPay invitation finalization returned status ${error.response.status} for user ${email}. Continuing without failing.`
+          );
+          return;
+        }
+        throw error;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Failed to finalize BTCPay invitation for ${email}: ${message}`);
+    }
   }
 
   private createHttp(): AxiosInstance {

--- a/apps/bff/test/auth.e2e-spec.ts
+++ b/apps/bff/test/auth.e2e-spec.ts
@@ -102,6 +102,7 @@ describe('AuthModule (e2e)', () => {
     const signupEmail = 'second@example.com';
     const signupPassword = 'averysecurepassword';
 
+    const invitationPath = '/invitations/accept?code=xyz';
     const scope = nock(btcpayUrl.origin)
       .post(`${apiBasePath}/api/v1/users`, (body: any) => {
         expect(body).toEqual(
@@ -115,6 +116,11 @@ describe('AuthModule (e2e)', () => {
       })
       .matchHeader('Authorization', `token ${adminToken}`)
       .reply(200, { id: 'user-second', email: signupEmail })
+      .get(`${apiBasePath}/api/v1/users/${encodeURIComponent(signupEmail)}`)
+      .matchHeader('Authorization', `token ${adminToken}`)
+      .reply(200, { invitationUrl: `${btcpayUrl.origin}${invitationPath}` })
+      .get(invitationPath)
+      .reply(302, undefined, { Location: '/login' })
       .post(`${apiBasePath}/api/v1/users/${encodeURIComponent(signupEmail)}/api-keys`, (body: any) => {
         expect(body).toEqual({ label: 'PayPay Portal', permissions: BTCPAY_PORTAL_USER_PERMISSIONS });
         return true;

--- a/apps/bff/test/auth.signup-provisioning.e2e-spec.ts
+++ b/apps/bff/test/auth.signup-provisioning.e2e-spec.ts
@@ -73,6 +73,7 @@ describe('Auth signup provisioning (e2e)', () => {
     const btcpayUrl = new URL(btcpayBase);
     const apiBasePath = btcpayUrl.pathname.replace(/\/$/, '');
 
+    const invitationPath = '/invitations/accept?code=abc';
     const scope = nock(btcpayUrl.origin)
       .post(`${apiBasePath}/api/v1/users`, (body: any) => {
         expect(body).toEqual(
@@ -86,6 +87,11 @@ describe('Auth signup provisioning (e2e)', () => {
       })
       .matchHeader('Authorization', `token ${adminToken}`)
       .reply(200, { id: 'user-provisioned', email })
+      .get(`${apiBasePath}/api/v1/users/${encodeURIComponent(email)}`)
+      .matchHeader('Authorization', `token ${adminToken}`)
+      .reply(200, { invitationUrl: `${btcpayUrl.origin}${invitationPath}` })
+      .get(invitationPath)
+      .reply(302, undefined, { Location: '/login' })
       .post(`${apiBasePath}/api/v1/users/${encodeURIComponent(email)}/api-keys`, (body: any) => {
         expect(body).toEqual({ label: 'PayPay Portal', permissions: BTCPAY_PORTAL_USER_PERMISSIONS });
         return true;


### PR DESCRIPTION
## Summary
- finalize BTCPay invitations after provisioning BTCPay accounts so they no longer remain in pending status
- update auth signup end-to-end tests to cover invitation finalization workflow

## Testing
- pnpm --filter bff exec jest --config jest.config.ts

------
https://chatgpt.com/codex/tasks/task_e_68dfffe44124832f88ba759e3ed11c51