### PR TITLE
refactor store creation to reuse onboarding btcpay key

### DIFF
--- a/apps/bff/src/btcpay/btcpay.service.ts
+++ b/apps/bff/src/btcpay/btcpay.service.ts
@@ -38,6 +38,16 @@ interface StoreResponse {
   name?: string;
 }
 
+interface CurrentApiKeyResponse {
+  label?: string;
+  permissions?: string[];
+}
+
+interface ApiKeyDetails {
+  label?: string;
+  permissions: string[];
+}
+
 interface UserResponse {
   id: string;
   email: string;
@@ -165,7 +175,7 @@ export class BtcpayService {
   async createStoreWithUserToken(
     host: string | undefined,
     apiKey: string,
-    payload: { name: string; website?: string }
+    payload: { name: string; website?: string; defaultCurrency?: string; preferredExchange?: string }
   ): Promise<StoreResponse> {
     const http = this.createHttp(host ?? this.config.baseUrl, {
       Authorization: `token ${apiKey}`
@@ -175,8 +185,31 @@ export class BtcpayService {
       if (payload.website) {
         body.website = payload.website;
       }
+      if (payload.defaultCurrency) {
+        body.defaultCurrency = payload.defaultCurrency;
+      }
+      if (payload.preferredExchange) {
+        body.preferredExchange = payload.preferredExchange;
+      }
       const { data } = await http.post<StoreResponse>('/api/v1/stores', body);
       return data;
+    } catch (error) {
+      return this.maskError(error);
+    }
+  }
+
+  async getCurrentApiKey(host: string | undefined, apiKey: string): Promise<ApiKeyDetails> {
+    const http = this.createHttp(host ?? this.config.baseUrl, {
+      Authorization: `token ${apiKey}`
+    });
+    try {
+      const { data } = await http.get<CurrentApiKeyResponse>('/api/v1/api-keys/current');
+      const rawPermissions = Array.isArray(data?.permissions) ? data.permissions ?? [] : [];
+      const permissions = rawPermissions.filter((permission): permission is string => typeof permission === 'string');
+      return {
+        label: typeof data?.label === 'string' ? data.label : undefined,
+        permissions
+      } satisfies ApiKeyDetails;
     } catch (error) {
       return this.maskError(error);
     }

--- a/apps/bff/src/migrations/1729300000000-AddTenantManagedStoreKeys.ts
+++ b/apps/bff/src/migrations/1729300000000-AddTenantManagedStoreKeys.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTenantManagedStoreKeys1729300000000 implements MigrationInterface {
+  name = 'AddTenantManagedStoreKeys1729300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "stores" ADD COLUMN IF NOT EXISTS "api_key_managed_by_tenant" boolean NOT NULL DEFAULT false'
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "stores" DROP COLUMN IF EXISTS "api_key_managed_by_tenant"');
+  }
+}

--- a/apps/bff/src/tenants/dto/create-store.dto.ts
+++ b/apps/bff/src/tenants/dto/create-store.dto.ts
@@ -5,9 +5,13 @@ export class CreateStoreDto {
   @IsNotEmpty()
   storeName!: string;
 
-  @IsUrl({ require_tld: false })
+  @IsString()
+  @IsNotEmpty()
+  defaultCurrency!: string;
+
+  @IsString()
   @IsOptional()
-  btcpayHost?: string;
+  preferredExchange?: string;
 
   @IsUrl({ require_tld: false })
   @IsOptional()

--- a/apps/bff/src/tenants/entities/store.entity.ts
+++ b/apps/bff/src/tenants/entities/store.entity.ts
@@ -37,6 +37,9 @@ export class StoreEntity {
   @Column({ name: 'store_key_last_four', type: 'varchar', nullable: true, length: 4 })
   storeKeyLastFour!: string | null;
 
+  @Column({ name: 'api_key_managed_by_tenant', type: 'boolean', default: false })
+  apiKeyManagedByTenant!: boolean;
+
   @Column({ name: 'api_key_ciphertext', type: 'text' })
   apiKeyCiphertext!: string;
 

--- a/apps/bff/src/tenants/tenants.service.ts
+++ b/apps/bff/src/tenants/tenants.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ForbiddenException,
   Injectable,
   InternalServerErrorException,
@@ -15,6 +16,7 @@ import { CreateTenantDto } from './dto/create-tenant.dto';
 import { CreateStoreDto } from './dto/create-store.dto';
 import { EnvelopeEncryptionService } from '../security/envelope-encryption.service';
 import { BtcpayService } from '../btcpay/btcpay.service';
+import { BTCPAY_MINIMAL_PERMISSIONS } from '../btcpay/btcpay.constants';
 import { CreateTenantInvoiceDto } from './dto/create-invoice.dto';
 import { normalizeEmail } from '../auth/email.utils';
 
@@ -30,13 +32,12 @@ export interface StoreSettingsResult {
   storeName: string | null;
   storeWebsite: string | null;
   storeKeyLastFour: string | null;
+  apiKeyManagedByTenant: boolean;
 }
 
 @Injectable()
 export class TenantsService {
   private readonly logger = new Logger(TenantsService.name, { timestamp: false });
-  private static readonly TEMPORARY_STORE_PERMISSION = ['btcpay.store.canmodifystoresettings'];
-
   constructor(
     @InjectRepository(TenantEntity)
     private readonly tenantsRepository: Repository<TenantEntity>,
@@ -60,40 +61,34 @@ export class TenantsService {
       sendInvitationEmail: true
     });
 
-    const temporaryKey = await this.btcpayService.createUserApiKeyUnscoped(
+    const persistentKey = await this.btcpayService.createUserApiKeyUnscoped(
       baseUrl,
       dto.email,
-      TenantsService.TEMPORARY_STORE_PERMISSION,
-      'Temp store setup'
+      BTCPAY_MINIMAL_PERMISSIONS,
+      'PayPay Portal access'
     );
 
     let store: { id: string };
     try {
-      store = await this.btcpayService.createStoreWithUserToken(baseUrl, temporaryKey.apiKey, {
+      store = await this.btcpayService.createStoreWithUserToken(baseUrl, persistentKey.apiKey, {
         name: dto.storeName,
         ...(storeWebsite ? { website: storeWebsite } : {})
       });
     } catch (error) {
-      await this.safeDeleteTemporaryKey(baseUrl, temporaryKey.apiKey);
-      this.clearBuffer(temporaryKey.apiKey);
+      this.clearBuffer(persistentKey.apiKey);
       throw error;
     }
 
-    await this.safeDeleteTemporaryKey(baseUrl, temporaryKey.apiKey);
-    this.clearBuffer(temporaryKey.apiKey);
-
     try {
-      const apiKey = await this.btcpayService.createUserApiKey(baseUrl, dto.email, store.id);
-      const webhook = await this.btcpayService.registerWebhook(baseUrl, apiKey.apiKey, store.id);
+      const webhook = await this.btcpayService.registerWebhook(baseUrl, persistentKey.apiKey, store.id);
       if (!webhook.secret) {
         throw new InternalServerErrorException('BTCPay webhook secret was not returned');
       }
 
-      const lastFour = this.extractLastFour(apiKey.apiKey);
-      const encryptedApiKey = this.encryptionService.encrypt(apiKey.apiKey);
+      const lastFour = this.extractLastFour(persistentKey.apiKey);
+      const encryptedApiKey = this.encryptionService.encrypt(persistentKey.apiKey);
       const encryptedWebhook = this.encryptionService.encrypt(webhook.secret, encryptedApiKey.dekWrapped);
 
-      this.clearBuffer(apiKey.apiKey);
       this.clearBuffer(webhook.secret);
 
       return this.dataSource.transaction(async (manager) => {
@@ -115,7 +110,8 @@ export class TenantsService {
           webhookId: webhook.id,
           webhookSecretCiphertext: encryptedWebhook.ciphertext,
           webhookSecretDekWrapped: encryptedWebhook.dekWrapped,
-          walletSetupStatus: 'pending'
+          walletSetupStatus: 'pending',
+          apiKeyManagedByTenant: false
         });
         await manager.getRepository(StoreEntity).save(storeEntity);
 
@@ -137,6 +133,8 @@ export class TenantsService {
     } catch (error) {
       this.logger.error('Failed to onboard tenant', (error as Error).message);
       throw error;
+    } finally {
+      this.clearBuffer(persistentKey.apiKey);
     }
   }
 
@@ -147,77 +145,72 @@ export class TenantsService {
     ip: string | null,
     requesterEmail: string | null
   ) {
-    const tenant = await this.requireTenantOwner(tenantId, requesterEmail);
+    await this.requireTenantOwner(tenantId, requesterEmail);
     const primaryStore = await this.storesRepository.findOne({ where: { tenantId }, order: { createdAt: 'ASC' } });
-    const baseUrl = this.btcpayService.resolveBaseUrl(dto.btcpayHost ?? primaryStore?.btcpayHost);
+    if (!primaryStore) {
+      throw new BadRequestException('Primary store is not available for this tenant.');
+    }
+
+    const baseUrl = this.btcpayService.resolveBaseUrl(primaryStore.btcpayHost);
     const storeWebsite = this.sanitizeWebsite(dto.storeWebsite);
 
-    const temporaryKey = await this.btcpayService.createUserApiKeyUnscoped(
-      baseUrl,
-      tenant.email,
-      TenantsService.TEMPORARY_STORE_PERMISSION,
-      'Temp store setup'
-    );
+    const normalizedCurrency = this.normalizeCurrency(dto.defaultCurrency);
+    const apiKey = this.encryptionService.decrypt(primaryStore.apiKeyCiphertext, primaryStore.apiKeyDekWrapped);
 
-    let store: { id: string };
     try {
-      store = await this.btcpayService.createStoreWithUserToken(baseUrl, temporaryKey.apiKey, {
+      const store = await this.btcpayService.createStoreWithUserToken(baseUrl, apiKey, {
         name: dto.storeName,
-        ...(storeWebsite ? { website: storeWebsite } : {})
+        ...(storeWebsite ? { website: storeWebsite } : {}),
+        defaultCurrency: normalizedCurrency,
+        preferredExchange: this.sanitizePreferredExchange(dto.preferredExchange)
       });
-    } catch (error) {
-      await this.safeDeleteTemporaryKey(baseUrl, temporaryKey.apiKey);
-      this.clearBuffer(temporaryKey.apiKey);
-      throw error;
+
+      const webhook = await this.btcpayService.registerWebhook(baseUrl, apiKey, store.id);
+      if (!webhook.secret) {
+        throw new InternalServerErrorException('BTCPay webhook secret was not returned');
+      }
+
+      const lastFour = this.extractLastFour(apiKey);
+      const encryptedApiKey = this.encryptionService.encrypt(apiKey);
+      const encryptedWebhook = this.encryptionService.encrypt(webhook.secret, encryptedApiKey.dekWrapped);
+
+      this.clearBuffer(webhook.secret);
+
+      return this.dataSource.transaction(async (manager) => {
+        const storeEntity = manager.getRepository(StoreEntity).create({
+          tenantId,
+          btcpayHost: baseUrl,
+          btcpayStoreId: store.id,
+          storeName: dto.storeName,
+          storeWebsite: storeWebsite ?? null,
+          storeKeyLastFour: lastFour,
+          apiKeyCiphertext: encryptedApiKey.ciphertext,
+          apiKeyDekWrapped: encryptedApiKey.dekWrapped,
+          webhookId: webhook.id,
+          webhookSecretCiphertext: encryptedWebhook.ciphertext,
+          webhookSecretDekWrapped: encryptedWebhook.dekWrapped,
+          walletSetupStatus: 'pending',
+          apiKeyManagedByTenant: false
+        });
+        await manager.getRepository(StoreEntity).save(storeEntity);
+
+        await manager.getRepository(AuditLogEntity).save({
+          tenantId,
+          actorId,
+          action: 'tenant.store.created',
+          resource: storeEntity.id,
+          result: 'success',
+          ip
+        });
+
+        return {
+          storeId: storeEntity.id,
+          btcpayStoreId: store.id
+        };
+      });
+    } finally {
+      this.clearBuffer(apiKey);
     }
-
-    await this.safeDeleteTemporaryKey(baseUrl, temporaryKey.apiKey);
-    this.clearBuffer(temporaryKey.apiKey);
-
-    const apiKey = await this.btcpayService.createUserApiKey(baseUrl, tenant.email, store.id);
-    const webhook = await this.btcpayService.registerWebhook(baseUrl, apiKey.apiKey, store.id);
-    if (!webhook.secret) {
-      throw new InternalServerErrorException('BTCPay webhook secret was not returned');
-    }
-
-    const lastFour = this.extractLastFour(apiKey.apiKey);
-    const encryptedApiKey = this.encryptionService.encrypt(apiKey.apiKey);
-    const encryptedWebhook = this.encryptionService.encrypt(webhook.secret, encryptedApiKey.dekWrapped);
-
-    this.clearBuffer(apiKey.apiKey);
-    this.clearBuffer(webhook.secret);
-
-    return this.dataSource.transaction(async (manager) => {
-      const storeEntity = manager.getRepository(StoreEntity).create({
-        tenantId,
-        btcpayHost: baseUrl,
-        btcpayStoreId: store.id,
-        storeName: dto.storeName,
-        storeWebsite: storeWebsite ?? null,
-        storeKeyLastFour: lastFour,
-        apiKeyCiphertext: encryptedApiKey.ciphertext,
-        apiKeyDekWrapped: encryptedApiKey.dekWrapped,
-        webhookId: webhook.id,
-        webhookSecretCiphertext: encryptedWebhook.ciphertext,
-        webhookSecretDekWrapped: encryptedWebhook.dekWrapped,
-        walletSetupStatus: 'pending'
-      });
-      await manager.getRepository(StoreEntity).save(storeEntity);
-
-      await manager.getRepository(AuditLogEntity).save({
-        tenantId,
-        actorId,
-        action: 'tenant.store.created',
-        resource: storeEntity.id,
-        result: 'success',
-        ip
-      });
-
-      return {
-        storeId: storeEntity.id,
-        btcpayStoreId: store.id
-      };
-    });
   }
 
   async createInvoice(tenantId: string, dto: CreateTenantInvoiceDto, requesterEmail: string | null) {
@@ -289,7 +282,8 @@ export class TenantsService {
       btcpayStoreId: store.btcpayStoreId,
       storeName,
       storeWebsite,
-      storeKeyLastFour: store.storeKeyLastFour ?? null
+      storeKeyLastFour: store.storeKeyLastFour ?? null,
+      apiKeyManagedByTenant: store.apiKeyManagedByTenant
     } satisfies StoreSettingsResult;
   }
 
@@ -302,6 +296,12 @@ export class TenantsService {
     const store = await this.storesRepository.findOne({ where: { id: storeId, tenantId } });
     if (!store) {
       throw new NotFoundException('Store not found');
+    }
+
+    if (store.apiKeyManagedByTenant) {
+      throw new ForbiddenException(
+        'Store API key rotation is not available for merchant-managed credentials. Update the key from BTCPay and resync.'
+      );
     }
 
     const tenant = await this.requireTenantOwner(tenantId, requesterEmail);
@@ -360,7 +360,9 @@ export class TenantsService {
       await this.tryDeleteWebhook(store, apiKey);
       await this.tryDeleteStore(store, apiKey);
     } finally {
-      await this.tryRevokeStoreApiKey(store, apiKey);
+      if (!store.apiKeyManagedByTenant) {
+        await this.tryRevokeStoreApiKey(store, apiKey);
+      }
       this.clearBuffer(apiKey);
     }
 
@@ -396,6 +398,25 @@ export class TenantsService {
       }
       throw error;
     }
+  }
+
+  private normalizeCurrency(value: string): string {
+    if (!value) {
+      throw new BadRequestException('Default currency is required.');
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      throw new BadRequestException('Default currency is required.');
+    }
+    return trimmed.toUpperCase();
+  }
+
+  private sanitizePreferredExchange(value?: string | null): string | undefined {
+    if (!value) {
+      return undefined;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
   }
 
   private clearBuffer(value: string | Buffer | null | undefined) {
@@ -486,11 +507,4 @@ export class TenantsService {
     }
   }
 
-  private async safeDeleteTemporaryKey(baseUrl: string, apiKey: string) {
-    try {
-      await this.btcpayService.deleteApiKey(baseUrl, apiKey);
-    } catch (error) {
-      this.logger.warn(`Failed to revoke temporary BTCPay API key: ${(error as Error).message}`);
-    }
-  }
 }

--- a/apps/bff/src/tenants/tenants.service.ts
+++ b/apps/bff/src/tenants/tenants.service.ts
@@ -307,21 +307,70 @@ export class TenantsService {
     const tenant = await this.requireTenantOwner(tenantId, requesterEmail);
 
     const oldApiKey = this.encryptionService.decrypt(store.apiKeyCiphertext, store.apiKeyDekWrapped);
-    const webhookSecret = this.encryptionService.decrypt(store.webhookSecretCiphertext, store.webhookSecretDekWrapped);
 
+    let newApiKeyPlain: string | null = null;
     try {
-      const apiKey = await this.btcpayService.createUserApiKey(store.btcpayHost, tenant.email, store.btcpayStoreId);
-      const lastFour = this.extractLastFour(apiKey.apiKey);
-      const encryptedApiKey = this.encryptionService.encrypt(apiKey.apiKey);
-      const encryptedWebhook = this.encryptionService.encrypt(webhookSecret, encryptedApiKey.dekWrapped);
+      const tenantStores = await this.storesRepository.find({ where: { tenantId } });
 
-      await this.storesRepository.update(store.id, {
-        apiKeyCiphertext: encryptedApiKey.ciphertext,
-        apiKeyDekWrapped: encryptedApiKey.dekWrapped,
-        webhookSecretCiphertext: encryptedWebhook.ciphertext,
-        webhookSecretDekWrapped: encryptedWebhook.dekWrapped,
-        storeKeyLastFour: lastFour
+      const storesSharingKey = tenantStores.filter((candidate) => {
+        if (candidate.apiKeyManagedByTenant) {
+          return false;
+        }
+        if (candidate.id === store.id) {
+          return true;
+        }
+        const candidateKey = this.encryptionService.decrypt(
+          candidate.apiKeyCiphertext,
+          candidate.apiKeyDekWrapped
+        );
+        try {
+          return candidateKey === oldApiKey;
+        } finally {
+          this.clearBuffer(candidateKey);
+        }
       });
+
+      if (storesSharingKey.length === 0) {
+        storesSharingKey.push(store);
+      }
+
+      const apiKey = await this.btcpayService.createUserApiKey(
+        store.btcpayHost,
+        tenant.email,
+        store.btcpayStoreId
+      );
+      newApiKeyPlain = apiKey.apiKey;
+      const lastFour = this.extractLastFour(newApiKeyPlain);
+
+      const nextApiKey = newApiKeyPlain;
+      if (!nextApiKey) {
+        throw new InternalServerErrorException('BTCPay API key rotation failed');
+      }
+
+      await Promise.all(
+        storesSharingKey.map(async (candidate) => {
+          const encryptedApiKey = this.encryptionService.encrypt(nextApiKey);
+          const webhookSecret = this.encryptionService.decrypt(
+            candidate.webhookSecretCiphertext,
+            candidate.webhookSecretDekWrapped
+          );
+          try {
+            const encryptedWebhook = this.encryptionService.encrypt(
+              webhookSecret,
+              encryptedApiKey.dekWrapped
+            );
+            await this.storesRepository.update(candidate.id, {
+              apiKeyCiphertext: encryptedApiKey.ciphertext,
+              apiKeyDekWrapped: encryptedApiKey.dekWrapped,
+              webhookSecretCiphertext: encryptedWebhook.ciphertext,
+              webhookSecretDekWrapped: encryptedWebhook.dekWrapped,
+              storeKeyLastFour: lastFour
+            });
+          } finally {
+            this.clearBuffer(webhookSecret);
+          }
+        })
+      );
 
       await this.auditRepository.save({
         tenantId,
@@ -338,7 +387,7 @@ export class TenantsService {
       return { lastFour };
     } finally {
       this.clearBuffer(oldApiKey);
-      this.clearBuffer(webhookSecret);
+      this.clearBuffer(newApiKeyPlain);
     }
   }
 
@@ -356,11 +405,32 @@ export class TenantsService {
     }
 
     const apiKey = this.encryptionService.decrypt(store.apiKeyCiphertext, store.apiKeyDekWrapped);
+    let shouldRevokeKey = !store.apiKeyManagedByTenant;
+    if (shouldRevokeKey) {
+      const siblingStores = await this.storesRepository.find({ where: { tenantId } });
+      for (const sibling of siblingStores) {
+        if (sibling.id === store.id || sibling.apiKeyManagedByTenant) {
+          continue;
+        }
+        const siblingKey = this.encryptionService.decrypt(
+          sibling.apiKeyCiphertext,
+          sibling.apiKeyDekWrapped
+        );
+        try {
+          if (siblingKey === apiKey) {
+            shouldRevokeKey = false;
+            break;
+          }
+        } finally {
+          this.clearBuffer(siblingKey);
+        }
+      }
+    }
     try {
       await this.tryDeleteWebhook(store, apiKey);
       await this.tryDeleteStore(store, apiKey);
     } finally {
-      if (!store.apiKeyManagedByTenant) {
+      if (shouldRevokeKey) {
         await this.tryRevokeStoreApiKey(store, apiKey);
       }
       this.clearBuffer(apiKey);

--- a/apps/bff/test/tenants.service.spec.ts
+++ b/apps/bff/test/tenants.service.spec.ts
@@ -5,6 +5,7 @@ import { StoreEntity } from '../src/tenants/entities/store.entity';
 import { AuditLogEntity } from '../src/tenants/entities/audit-log.entity';
 import { EnvelopeEncryptionService } from '../src/security/envelope-encryption.service';
 import { BtcpayService } from '../src/btcpay/btcpay.service';
+import { BTCPAY_MINIMAL_PERMISSIONS } from '../src/btcpay/btcpay.constants';
 
 describe('TenantsService onboarding flows', () => {
   function createService() {
@@ -29,7 +30,9 @@ describe('TenantsService onboarding flows', () => {
     const btcpayService = {
       resolveBaseUrl: jest.fn((host?: string) => host ?? 'https://btcpay.test'),
       createUser: jest.fn().mockResolvedValue({ id: 'user-1', email: 'merchant@example.com' }),
-      createUserApiKeyUnscoped: jest.fn().mockResolvedValue({ apiKey: 'temp-key', permissions: ['btcpay.store.canmodifystoresettings'] }),
+      createUserApiKeyUnscoped: jest
+        .fn()
+        .mockResolvedValue({ apiKey: 'persistent-key', permissions: ['btcpay.store.canmodifystoresettings'] }),
       createStoreWithUserToken: jest.fn().mockResolvedValue({ id: 'btcpay-store-id' }),
       deleteApiKey: jest.fn().mockResolvedValue(undefined),
       createUserApiKey: jest.fn().mockResolvedValue({ apiKey: 'store-key', permissions: [] }),
@@ -96,7 +99,7 @@ describe('TenantsService onboarding flows', () => {
     jest.resetAllMocks();
   });
 
-  it('creates tenants using temporary user keys and revokes them', async () => {
+  it('creates tenants with a persistent BTCPay API key', async () => {
     const {
       service,
       encryptionService,
@@ -129,26 +132,28 @@ describe('TenantsService onboarding flows', () => {
     expect(btcpayService.createUserApiKeyUnscoped).toHaveBeenCalledWith(
       'https://btcpay.custom',
       'merchant@example.com',
-      ['btcpay.store.canmodifystoresettings'],
-      'Temp store setup'
+      BTCPAY_MINIMAL_PERMISSIONS,
+      'PayPay Portal access'
     );
-    expect(btcpayService.createStoreWithUserToken).toHaveBeenCalledWith('https://btcpay.custom', 'temp-key', {
+    expect(btcpayService.createStoreWithUserToken).toHaveBeenCalledWith('https://btcpay.custom', 'persistent-key', {
       name: 'Demo Store'
     });
-    expect(btcpayService.deleteApiKey).toHaveBeenCalledWith('https://btcpay.custom', 'temp-key');
-    expect(btcpayService.createUserApiKey).toHaveBeenCalledWith(
+    expect(btcpayService.deleteApiKey).not.toHaveBeenCalled();
+    expect(btcpayService.createUserApiKey).not.toHaveBeenCalled();
+    expect(btcpayService.registerWebhook).toHaveBeenCalledWith(
       'https://btcpay.custom',
-      'merchant@example.com',
+      'persistent-key',
       'btcpay-store-id'
     );
-    expect(btcpayService.registerWebhook).toHaveBeenCalledWith('https://btcpay.custom', 'store-key', 'btcpay-store-id');
 
-    expect(encryptionService.encrypt).toHaveBeenNthCalledWith(1, 'store-key');
+    expect(encryptionService.encrypt).toHaveBeenNthCalledWith(1, 'persistent-key');
     expect(encryptionService.encrypt).toHaveBeenNthCalledWith(2, 'webhook-secret', 'api-dek');
 
     expect(dataSource.transaction).toHaveBeenCalledTimes(1);
     expect(tenantRepoInTx.create).toHaveBeenCalled();
-    expect(storeRepoInTx.create).toHaveBeenCalled();
+    expect(storeRepoInTx.create).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKeyManagedByTenant: false, storeKeyLastFour: 't-key' })
+    );
     expect(auditRepoInTx.save).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'tenant.created', actorId: 'actor-1' })
     );
@@ -160,7 +165,7 @@ describe('TenantsService onboarding flows', () => {
     });
   });
 
-  it('creates additional stores using the temporary user key flow', async () => {
+  it('creates additional stores using the persisted API key', async () => {
     const {
       service,
       tenantsRepository,
@@ -173,15 +178,21 @@ describe('TenantsService onboarding flows', () => {
     } = createService();
 
     tenantsRepository.findOne.mockResolvedValue({ id: 'tenant-entity-id', email: 'merchant@example.com' });
-    storesRepository.findOne.mockResolvedValue({ btcpayHost: 'https://btcpay.test' });
+    storesRepository.findOne.mockResolvedValue({
+      btcpayHost: 'https://btcpay.test',
+      apiKeyCiphertext: 'cipher-existing',
+      apiKeyDekWrapped: 'dek-existing'
+    });
 
+    (encryptionService.decrypt as jest.Mock).mockReturnValueOnce('stored-key');
     (encryptionService.encrypt as jest.Mock).mockReturnValueOnce({ ciphertext: 'api-cipher', dekWrapped: 'api-dek' });
     (encryptionService.encrypt as jest.Mock).mockReturnValueOnce({ ciphertext: 'webhook-cipher', dekWrapped: 'webhook-dek' });
 
     const result = await service.createAdditionalStore(
       'tenant-entity-id',
       {
-        storeName: 'Second Store'
+        storeName: 'Second Store',
+        defaultCurrency: 'USD'
       },
       'actor-2',
       '127.0.0.1',
@@ -189,28 +200,23 @@ describe('TenantsService onboarding flows', () => {
     );
 
     expect(btcpayService.createUser).not.toHaveBeenCalled();
-    expect(btcpayService.createUserApiKeyUnscoped).toHaveBeenCalledWith(
+    expect(btcpayService.createUserApiKeyUnscoped).not.toHaveBeenCalled();
+    expect(btcpayService.createStoreWithUserToken).toHaveBeenCalledWith(
       'https://btcpay.test',
-      'merchant@example.com',
-      ['btcpay.store.canmodifystoresettings'],
-      'Temp store setup'
+      'stored-key',
+      expect.objectContaining({ name: 'Second Store', defaultCurrency: 'USD' })
     );
-    expect(btcpayService.createStoreWithUserToken).toHaveBeenCalledWith('https://btcpay.test', 'temp-key', {
-      name: 'Second Store'
-    });
-    expect(btcpayService.deleteApiKey).toHaveBeenCalledWith('https://btcpay.test', 'temp-key');
-    expect(btcpayService.createUserApiKey).toHaveBeenCalledWith(
-      'https://btcpay.test',
-      'merchant@example.com',
-      'btcpay-store-id'
-    );
-    expect(btcpayService.registerWebhook).toHaveBeenCalledWith('https://btcpay.test', 'store-key', 'btcpay-store-id');
+    expect(btcpayService.deleteApiKey).not.toHaveBeenCalled();
+    expect(btcpayService.createUserApiKey).not.toHaveBeenCalled();
+    expect(btcpayService.registerWebhook).toHaveBeenCalledWith('https://btcpay.test', 'stored-key', 'btcpay-store-id');
 
-    expect(encryptionService.encrypt).toHaveBeenNthCalledWith(1, 'store-key');
+    expect(encryptionService.encrypt).toHaveBeenNthCalledWith(1, 'stored-key');
     expect(encryptionService.encrypt).toHaveBeenNthCalledWith(2, 'webhook-secret', 'api-dek');
 
     expect(dataSource.transaction).toHaveBeenCalledTimes(1);
-    expect(storeRepoInTx.create).toHaveBeenCalled();
+    expect(storeRepoInTx.create).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKeyManagedByTenant: false, storeKeyLastFour: 'd-key' })
+    );
     expect(auditRepoInTx.save).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'tenant.store.created', actorId: 'actor-2' })
     );

--- a/apps/bff/test/tenants.service.spec.ts
+++ b/apps/bff/test/tenants.service.spec.ts
@@ -14,6 +14,7 @@ describe('TenantsService onboarding flows', () => {
     } as unknown as jest.Mocked<any>;
     const storesRepository = {
       findOne: jest.fn(),
+      find: jest.fn(),
       update: jest.fn(),
       delete: jest.fn()
     } as unknown as jest.Mocked<any>;
@@ -152,7 +153,7 @@ describe('TenantsService onboarding flows', () => {
     expect(dataSource.transaction).toHaveBeenCalledTimes(1);
     expect(tenantRepoInTx.create).toHaveBeenCalled();
     expect(storeRepoInTx.create).toHaveBeenCalledWith(
-      expect.objectContaining({ apiKeyManagedByTenant: false, storeKeyLastFour: 't-key' })
+      expect.objectContaining({ apiKeyManagedByTenant: false, storeKeyLastFour: '-key' })
     );
     expect(auditRepoInTx.save).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'tenant.created', actorId: 'actor-1' })
@@ -215,7 +216,7 @@ describe('TenantsService onboarding flows', () => {
 
     expect(dataSource.transaction).toHaveBeenCalledTimes(1);
     expect(storeRepoInTx.create).toHaveBeenCalledWith(
-      expect.objectContaining({ apiKeyManagedByTenant: false, storeKeyLastFour: 'd-key' })
+      expect.objectContaining({ apiKeyManagedByTenant: false, storeKeyLastFour: '-key' })
     );
     expect(auditRepoInTx.save).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'tenant.store.created', actorId: 'actor-2' })
@@ -224,7 +225,7 @@ describe('TenantsService onboarding flows', () => {
     expect(result).toEqual({ storeId: 'store-entity-id', btcpayStoreId: 'btcpay-store-id' });
   });
 
-  it('rotates store API keys while revoking the previous key', async () => {
+  it('rotates shared store API keys and revokes the previous credential once', async () => {
     const {
       service,
       tenantsRepository,
@@ -235,7 +236,7 @@ describe('TenantsService onboarding flows', () => {
     } = createService();
 
     tenantsRepository.findOne.mockResolvedValue({ id: 'tenant-entity-id', email: 'merchant@example.com' });
-    storesRepository.findOne.mockResolvedValue({
+    const primaryStore = {
       id: 'store-entity-id',
       tenantId: 'tenant-entity-id',
       btcpayHost: 'https://btcpay.test',
@@ -244,11 +245,27 @@ describe('TenantsService onboarding flows', () => {
       apiKeyDekWrapped: 'dek-old',
       webhookSecretCiphertext: 'webhook-cipher',
       webhookSecretDekWrapped: 'webhook-dek'
-    });
+    };
+    const siblingStore = {
+      id: 'store-entity-id-2',
+      tenantId: 'tenant-entity-id',
+      btcpayHost: 'https://btcpay.test',
+      btcpayStoreId: 'btcpay-store-id-2',
+      apiKeyCiphertext: 'cipher-old-2',
+      apiKeyDekWrapped: 'dek-old-2',
+      webhookSecretCiphertext: 'webhook-cipher-2',
+      webhookSecretDekWrapped: 'webhook-dek-2',
+      apiKeyManagedByTenant: false
+    };
+
+    storesRepository.findOne.mockResolvedValue(primaryStore);
+    storesRepository.find.mockResolvedValue([primaryStore, siblingStore]);
 
     (encryptionService.decrypt as jest.Mock)
       .mockReturnValueOnce('store-key-0000')
-      .mockReturnValueOnce('webhook-secret-old');
+      .mockReturnValueOnce('store-key-0000')
+      .mockReturnValueOnce('webhook-secret-old')
+      .mockReturnValueOnce('webhook-secret-sibling');
 
     (btcpayService.createUserApiKey as jest.Mock).mockResolvedValue({
       apiKey: 'store-key-9999',
@@ -257,7 +274,9 @@ describe('TenantsService onboarding flows', () => {
 
     (encryptionService.encrypt as jest.Mock)
       .mockReturnValueOnce({ ciphertext: 'cipher-new', dekWrapped: 'dek-new' })
-      .mockReturnValueOnce({ ciphertext: 'webhook-cipher-new', dekWrapped: 'webhook-dek-new' });
+      .mockReturnValueOnce({ ciphertext: 'webhook-cipher-new', dekWrapped: 'webhook-dek-new' })
+      .mockReturnValueOnce({ ciphertext: 'cipher-new-2', dekWrapped: 'dek-new-2' })
+      .mockReturnValueOnce({ ciphertext: 'webhook-cipher-new-2', dekWrapped: 'webhook-dek-new-2' });
 
     const result = await service.rotateStoreApiKey(
       'tenant-entity-id',
@@ -281,6 +300,16 @@ describe('TenantsService onboarding flows', () => {
         storeKeyLastFour: '9999'
       })
     );
+    expect(storesRepository.update).toHaveBeenCalledWith(
+      'store-entity-id-2',
+      expect.objectContaining({
+        apiKeyCiphertext: 'cipher-new-2',
+        apiKeyDekWrapped: 'dek-new-2',
+        webhookSecretCiphertext: 'webhook-cipher-new-2',
+        webhookSecretDekWrapped: 'webhook-dek-new-2',
+        storeKeyLastFour: '9999'
+      })
+    );
     expect(auditRepository.save).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'tenant.store.apiKeyRotated', resource: 'store-entity-id' })
     );
@@ -288,7 +317,7 @@ describe('TenantsService onboarding flows', () => {
     expect(result).toEqual({ lastFour: '9999' });
   });
 
-  it('deletes stores by using the scoped key before revoking it', async () => {
+  it('deletes stores by using the scoped key before revoking it when no siblings share the credential', async () => {
     const {
       service,
       tenantsRepository,
@@ -300,15 +329,19 @@ describe('TenantsService onboarding flows', () => {
     } = createService();
 
     tenantsRepository.findOne.mockResolvedValue({ id: 'tenant-entity-id', email: 'merchant@example.com' });
-    storesRepository.findOne.mockResolvedValue({
+    const store = {
       id: 'store-entity-id',
       tenantId: 'tenant-entity-id',
       btcpayHost: 'https://btcpay.test',
       btcpayStoreId: 'btcpay-store-id',
       apiKeyCiphertext: 'cipher-old',
       apiKeyDekWrapped: 'dek-old',
-      webhookId: 'webhook-id-123'
-    });
+      webhookId: 'webhook-id-123',
+      apiKeyManagedByTenant: false
+    };
+
+    storesRepository.findOne.mockResolvedValue(store);
+    storesRepository.find.mockResolvedValue([store]);
 
     (encryptionService.decrypt as jest.Mock).mockReturnValueOnce('store-key-1111');
 
@@ -338,6 +371,73 @@ describe('TenantsService onboarding flows', () => {
     const deleteKeyOrder = btcpayService.deleteApiKey.mock.invocationCallOrder[0];
     expect(deleteWebhookOrder).toBeLessThan(deleteKeyOrder);
     expect(deleteStoreOrder).toBeLessThan(deleteKeyOrder);
+
+    expect(auditRepoInTx.save).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'tenant.store.deleted', resource: 'store-entity-id' })
+    );
+    expect(dataSource.transaction).toHaveBeenCalled();
+  });
+
+  it('does not revoke shared API keys when deleting a single store', async () => {
+    const {
+      service,
+      tenantsRepository,
+      storesRepository,
+      encryptionService,
+      btcpayService,
+      dataSource,
+      auditRepoInTx
+    } = createService();
+
+    tenantsRepository.findOne.mockResolvedValue({ id: 'tenant-entity-id', email: 'merchant@example.com' });
+    const store = {
+      id: 'store-entity-id',
+      tenantId: 'tenant-entity-id',
+      btcpayHost: 'https://btcpay.test',
+      btcpayStoreId: 'btcpay-store-id',
+      apiKeyCiphertext: 'cipher-old',
+      apiKeyDekWrapped: 'dek-old',
+      webhookId: 'webhook-id-123',
+      apiKeyManagedByTenant: false
+    };
+    const sibling = {
+      id: 'store-entity-id-2',
+      tenantId: 'tenant-entity-id',
+      btcpayHost: 'https://btcpay.test',
+      btcpayStoreId: 'btcpay-store-id-2',
+      apiKeyCiphertext: 'cipher-old-2',
+      apiKeyDekWrapped: 'dek-old-2',
+      webhookId: 'webhook-id-456',
+      apiKeyManagedByTenant: false
+    };
+
+    storesRepository.findOne.mockResolvedValue(store);
+    storesRepository.find.mockResolvedValue([store, sibling]);
+
+    (encryptionService.decrypt as jest.Mock)
+      .mockReturnValueOnce('store-key-1111')
+      .mockReturnValueOnce('store-key-1111');
+
+    await service.deleteStore(
+      'tenant-entity-id',
+      'store-entity-id',
+      'actor-4',
+      '127.0.0.1',
+      'merchant@example.com'
+    );
+
+    expect(btcpayService.deleteWebhook).toHaveBeenCalledWith(
+      'https://btcpay.test',
+      'store-key-1111',
+      'btcpay-store-id',
+      'webhook-id-123'
+    );
+    expect(btcpayService.deleteStore).toHaveBeenCalledWith(
+      'https://btcpay.test',
+      'store-key-1111',
+      'btcpay-store-id'
+    );
+    expect(btcpayService.deleteApiKey).not.toHaveBeenCalled();
 
     expect(auditRepoInTx.save).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'tenant.store.deleted', resource: 'store-entity-id' })

--- a/apps/frontend/app/portal/page.tsx
+++ b/apps/frontend/app/portal/page.tsx
@@ -15,7 +15,8 @@ export default function PortalPage() {
         <header className="mb-4 space-y-2">
           <h1 className="text-3xl font-semibold">Welcome to the PayPay portal</h1>
           <p className="text-sm text-muted-foreground">
-            Review your BTCPay integration status, rotate API keys and connect stores. Store creation is coming soon.
+            Review your BTCPay integration status, connect new stores with merchant API keys and manage credentials from a single
+            place.
           </p>
         </header>
         <Suspense fallback={null}>
@@ -27,11 +28,13 @@ export default function PortalPage() {
         <article className="rounded-xl border bg-background p-5 shadow-sm">
           <h2 className="text-lg font-semibold">Stores</h2>
           <p className="mt-2 text-sm text-muted-foreground">
-            Your BTCPay stores will appear here once provisioning is available. For now you can review your initial access key
-            and prepare branding assets.
+            Use the organization navigation to create stores, register webhooks and review settings linked to your BTCPay API
+            keys. Each store uses end-to-end encryption for credential storage.
           </p>
-          <Button disabled className="mt-4" variant="outline">
-            Create Store (coming soon)
+          <Button asChild className="mt-4" variant="outline">
+            <Link href="https://docs.btcpayserver.org/CreateStore/" target="_blank" rel="noopener noreferrer">
+              Review BTCPay guide
+            </Link>
           </Button>
         </article>
         <article className="rounded-xl border bg-background p-5 shadow-sm">

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/settings/page.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/settings/page.tsx
@@ -10,6 +10,7 @@ interface StoreSettingsResponse {
   storeName: string | null;
   storeWebsite: string | null;
   storeKeyLastFour: string | null;
+  apiKeyManagedByTenant: boolean;
 }
 
 async function fetchStoreSettings(tenantId: string, storeId: string): Promise<StoreSettingsResponse> {

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/settings/store-settings-client.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/settings/store-settings-client.tsx
@@ -11,6 +11,7 @@ interface StoreSettingsData {
   storeName: string | null;
   storeWebsite: string | null;
   storeKeyLastFour: string | null;
+  apiKeyManagedByTenant: boolean;
 }
 
 interface StoreSettingsClientProps {
@@ -36,8 +37,12 @@ export default function StoreSettingsClient({
   const router = useRouter();
 
   const maskedKey = data.storeKeyLastFour ? `****${data.storeKeyLastFour}` : "Unavailable";
+  const rotationDisabled = data.apiKeyManagedByTenant;
 
   const rotateKey = () => {
+    if (rotationDisabled) {
+      return;
+    }
     setError(null);
     setStatus(null);
     startRotate(async () => {
@@ -65,7 +70,11 @@ export default function StoreSettingsClient({
     setError(null);
     setStatus(null);
     if (typeof window !== "undefined") {
-      const confirmed = window.confirm("Delete this store and revoke its BTCPay access?");
+      const confirmed = window.confirm(
+        rotationDisabled
+          ? "Delete this store from the portal? Your BTCPay API key will remain active."
+          : "Delete this store and revoke its BTCPay access?"
+      );
       if (!confirmed) {
         return;
       }
@@ -141,17 +150,25 @@ export default function StoreSettingsClient({
           </div>
         </dl>
       </div>
-      <div className="flex flex-wrap gap-3">
-        <Button disabled={isRotating || isDeleting} onClick={rotateKey}>
-          {isRotating ? "Rotating…" : "Rotate Key"}
-        </Button>
-        <Button
-          disabled={isRotating || isDeleting}
-          onClick={deleteStore}
-          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-        >
-          {isDeleting ? "Deleting…" : "Delete Store"}
-        </Button>
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap gap-3">
+          <Button disabled={rotationDisabled || isRotating || isDeleting} onClick={rotateKey}>
+            {rotationDisabled ? "Rotation disabled" : isRotating ? "Rotating…" : "Rotate Key"}
+          </Button>
+          <Button
+            disabled={isRotating || isDeleting}
+            onClick={deleteStore}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isDeleting ? "Deleting…" : "Delete Store"}
+          </Button>
+        </div>
+        {rotationDisabled && (
+          <p className="text-sm text-muted-foreground">
+            Rotation is unavailable because this store uses a merchant-supplied API key. Generate a new key in BTCPay and update
+            the connection from the portal onboarding flow.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/app/tenants/[tenantId]/stores/create/create-store-client.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/create/create-store-client.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { ChangeEvent, FormEvent, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "../../../../../components/ui/button";
+import { api, isApiError } from "../../../../../lib/api";
+
+const REQUIRED_PERMISSIONS = [
+  "btcpay.store.canmodifystoresettings",
+  "btcpay.store.webhooks.canmodifywebhooks",
+  "btcpay.store.canviewstoresettings",
+  "btcpay.store.canviewreports",
+  "btcpay.store.cancreateinvoice",
+  "btcpay.store.canviewinvoices",
+  "btcpay.store.canmodifyinvoices",
+  "btcpay.store.canmodifypaymentrequests",
+  "btcpay.store.canviewpaymentrequests",
+  "btcpay.store.canviewpullpayments",
+  "btcpay.store.canmanagepullpayments",
+  "btcpay.store.canarchivepullpayments",
+  "btcpay.store.cancreatepullpayments",
+  "btcpay.store.cancreatenonapprovedpullpayments",
+  "btcpay.store.canmanagepayouts",
+  "btcpay.store.canviewpayouts"
+];
+
+interface CreateStoreClientProps {
+  tenantId: string;
+}
+
+interface CreateStoreResponse {
+  storeId: string;
+  btcpayStoreId: string;
+}
+
+export default function CreateStoreClient({ tenantId }: CreateStoreClientProps) {
+  const router = useRouter();
+  const [form, setForm] = useState({
+    storeName: "",
+    defaultCurrency: "USD",
+    preferredExchange: "coingecko",
+    storeWebsite: ""
+  });
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, startSubmit] = useTransition();
+
+  const updateField = (field: keyof typeof form) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setForm((prev) => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setStatus(null);
+
+    startSubmit(async () => {
+      try {
+        const payload = {
+          storeName: form.storeName.trim(),
+          defaultCurrency: form.defaultCurrency.trim().toUpperCase(),
+          preferredExchange: normalizeOptional(form.preferredExchange),
+          storeWebsite: normalizeOptional(form.storeWebsite)
+        };
+
+        const response = await api<CreateStoreResponse>(`/tenants/${tenantId}/stores`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json"
+          },
+          body: JSON.stringify(payload)
+        });
+
+        if (!response?.storeId) {
+          throw new Error("Store creation response did not include an identifier.");
+        }
+
+        setStatus("Store created successfully. Redirecting to settings…");
+        router.push(`/tenants/${tenantId}/stores/${response.storeId}/settings`);
+      } catch (submissionError) {
+        setError(resolveSubmissionError(submissionError));
+      }
+    });
+  };
+
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-8">
+      <section className="rounded-xl border bg-card p-6 shadow-sm">
+        <header className="mb-6 space-y-2">
+          <h1 className="text-2xl font-semibold">Create BTCPay Store</h1>
+          <p className="text-sm text-muted-foreground">
+            We will reuse the Greenfield API key that was provisioned for your account during signup to create the store and
+            register a webhook. Confirm the store details below and submit to finish.
+          </p>
+        </header>
+        {error && (
+          <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+        {status && !error && (
+          <div className="mb-4 rounded-md border border-primary/30 bg-primary/5 px-4 py-3 text-sm text-foreground">{status}</div>
+        )}
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="flex flex-col gap-2">
+              <label htmlFor="storeName" className="text-sm font-medium text-foreground">
+                Store name
+              </label>
+              <input
+                id="storeName"
+                name="storeName"
+                required
+                value={form.storeName}
+                onChange={updateField("storeName")}
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                placeholder="BTCPayServerDemo"
+                autoComplete="organization"
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <label htmlFor="defaultCurrency" className="text-sm font-medium text-foreground">
+                Default currency
+              </label>
+              <input
+                id="defaultCurrency"
+                name="defaultCurrency"
+                required
+                value={form.defaultCurrency}
+                onChange={updateField("defaultCurrency")}
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm uppercase shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                placeholder="USD"
+                autoComplete="off"
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <label htmlFor="preferredExchange" className="text-sm font-medium text-foreground">
+                Rate provider (optional)
+              </label>
+              <input
+                id="preferredExchange"
+                name="preferredExchange"
+                value={form.preferredExchange}
+                onChange={updateField("preferredExchange")}
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                placeholder="coingecko"
+                autoComplete="off"
+              />
+              <p className="text-xs text-muted-foreground">
+                Use provider identifiers from the BTCPay "Rates" settings, for example <code>coingecko</code> or <code>bitfinex</code>.
+              </p>
+            </div>
+            <div className="flex flex-col gap-2 md:col-span-2">
+              <label htmlFor="storeWebsite" className="text-sm font-medium text-foreground">
+                Store website (optional)
+              </label>
+              <input
+                id="storeWebsite"
+                name="storeWebsite"
+                value={form.storeWebsite}
+                onChange={updateField("storeWebsite")}
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                placeholder="https://merchant.example.com"
+                type="url"
+                autoComplete="url"
+              />
+            </div>
+          </div>
+          <div>
+            <Button type="submit" disabled={isSubmitting} className="w-full md:w-auto">
+              {isSubmitting ? "Creating…" : "Create store"}
+            </Button>
+          </div>
+        </form>
+      </section>
+      <section className="rounded-xl border bg-muted/30 p-6 text-sm shadow-sm">
+        <h2 className="text-lg font-semibold">Required BTCPay permissions</h2>
+        <p className="mt-2 text-muted-foreground">
+          The managed API key used by the portal includes at least the following permissions to support store setup, webhook
+          registration and payment operations:
+        </p>
+        <ul className="mt-4 grid gap-2 md:grid-cols-2">
+          {REQUIRED_PERMISSIONS.map((permission) => (
+            <li key={permission} className="rounded-md border bg-background px-3 py-2 font-mono text-xs">
+              {permission}
+            </li>
+          ))}
+        </ul>
+        <p className="mt-4 text-muted-foreground">
+          See the BTCPay Server guide for additional context:
+          <a
+            className="ml-1 text-primary underline-offset-4 hover:underline"
+            href="https://docs.btcpayserver.org/CreateStore/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Create Store documentation
+          </a>
+          .
+        </p>
+      </section>
+    </div>
+  );
+}
+
+function normalizeOptional(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function resolveSubmissionError(error: unknown): string {
+  const fallback = "Failed to create BTCPay store.";
+
+  if (isApiError(error)) {
+    const body = error.body as any;
+    const message = typeof body?.message === "string" ? body.message.trim() : null;
+    if (message) {
+      return message;
+    }
+    if (Array.isArray(body)) {
+      const items = body.map((item) => (typeof item === "string" ? item.trim() : "")).filter((item) => item.length > 0);
+      if (items.length > 0) {
+        return items.join("\n");
+      }
+    }
+    return `${fallback} (status ${error.status}).`;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+}

--- a/apps/frontend/app/tenants/[tenantId]/stores/create/page.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/create/page.tsx
@@ -1,0 +1,13 @@
+import type { ReactElement } from "react";
+import CreateStoreClient from "./create-store-client";
+
+type CreateStorePageParams = {
+  tenantId: string;
+};
+
+async function CreateStorePage({ params }: { params: Promise<CreateStorePageParams> }) {
+  const { tenantId } = await params;
+  return <CreateStoreClient tenantId={tenantId} />;
+}
+
+export default CreateStorePage as unknown as (props: any) => Promise<ReactElement>;


### PR DESCRIPTION
## Summary
- reuse the onboarding BTCPay API key for tenant creation and additional stores instead of issuing temporary credentials
- update DTOs and service tests to reflect managed API keys and guard against missing primary stores
- simplify the store creation UI by removing host/API key inputs and clarifying that the portal-managed key is reused

## Testing
- pnpm --filter bff build
- pnpm --filter frontend lint *(fails: repository lacks eslint.config.js for ESLint v9)*

------
https://chatgpt.com/codex/tasks/task_e_68e1171ecfb8832f9a7ae1d823c2a365