### PR TITLE
Add tenant store navigation and listings

### DIFF
--- a/apps/bff/src/tenants/tenants.controller.ts
+++ b/apps/bff/src/tenants/tenants.controller.ts
@@ -40,6 +40,12 @@ export class TenantsController {
     return this.tenantsService.createAdditionalStore(tenantId, dto, actorId, ip, email);
   }
 
+  @Get(':tenantId/stores')
+  listStores(@Param('tenantId', ParseUUIDPipe) tenantId: string, @Req() req: Request) {
+    const email = this.resolveUserEmail(req);
+    return this.tenantsService.listTenantStores(tenantId, email);
+  }
+
   @Get(':tenantId/stores/:storeId')
   getStoreSettings(
     @Param('tenantId', ParseUUIDPipe) tenantId: string,

--- a/apps/bff/src/tenants/tenants.service.ts
+++ b/apps/bff/src/tenants/tenants.service.ts
@@ -32,7 +32,22 @@ export interface StoreSettingsResult {
   storeName: string | null;
   storeWebsite: string | null;
   storeKeyLastFour: string | null;
+  btcpayHost: string;
+  walletSetupStatus: string;
   apiKeyManagedByTenant: boolean;
+}
+
+export interface TenantStoreSummary {
+  storeId: string;
+  btcpayStoreId: string;
+  storeName: string | null;
+  storeWebsite: string | null;
+  storeKeyLastFour: string | null;
+  btcpayHost: string;
+  walletSetupStatus: string;
+  apiKeyManagedByTenant: boolean;
+  createdAt: string;
+  updatedAt: string;
 }
 
 @Injectable()
@@ -213,6 +228,27 @@ export class TenantsService {
     }
   }
 
+  async listTenantStores(tenantId: string, requesterEmail: string | null): Promise<TenantStoreSummary[]> {
+    await this.requireTenantOwner(tenantId, requesterEmail);
+    const stores = await this.storesRepository.find({
+      where: { tenantId },
+      order: { createdAt: 'ASC' }
+    });
+
+    return stores.map((store) => ({
+      storeId: store.id,
+      btcpayStoreId: store.btcpayStoreId,
+      storeName: store.storeName ?? null,
+      storeWebsite: store.storeWebsite ?? null,
+      storeKeyLastFour: store.storeKeyLastFour ?? null,
+      btcpayHost: store.btcpayHost,
+      walletSetupStatus: store.walletSetupStatus,
+      apiKeyManagedByTenant: store.apiKeyManagedByTenant,
+      createdAt: store.createdAt.toISOString(),
+      updatedAt: store.updatedAt.toISOString()
+    }));
+  }
+
   async createInvoice(tenantId: string, dto: CreateTenantInvoiceDto, requesterEmail: string | null) {
     await this.requireTenantOwner(tenantId, requesterEmail);
     const store = await this.storesRepository.findOne({ where: { id: dto.storeId, tenantId } });
@@ -282,6 +318,8 @@ export class TenantsService {
       btcpayStoreId: store.btcpayStoreId,
       storeName,
       storeWebsite,
+      btcpayHost: store.btcpayHost,
+      walletSetupStatus: store.walletSetupStatus,
       storeKeyLastFour: store.storeKeyLastFour ?? null,
       apiKeyManagedByTenant: store.apiKeyManagedByTenant
     } satisfies StoreSettingsResult;

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/checkout-integrations/api-keys/page.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/checkout-integrations/api-keys/page.tsx
@@ -1,0 +1,15 @@
+import type { ReactElement } from "react";
+import { StoreFeaturePlaceholder } from "../../store-feature-placeholder";
+
+async function ApiKeysPage(): Promise<ReactElement> {
+  return (
+    <StoreFeaturePlaceholder
+      title="API Keys"
+      description="Generate and rotate BTCPay Greenfield API keys scoped to this store. Portal automation will surface here soon."
+      documentationUrl="https://docs.btcpayserver.org/GreenField/v1/"
+      documentationLabel="Greenfield API reference"
+    />
+  );
+}
+
+export default ApiKeysPage as unknown as () => Promise<ReactElement>;

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/dashboard/page.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/dashboard/page.tsx
@@ -1,0 +1,15 @@
+import type { ReactElement } from "react";
+import { StoreFeaturePlaceholder } from "../store-feature-placeholder";
+
+async function DashboardPage(): Promise<ReactElement> {
+  return (
+    <StoreFeaturePlaceholder
+      title="Dashboard"
+      description="Wallet balances, invoice statistics and crowdfund summaries will surface here."
+      documentationUrl="https://docs.btcpayserver.org/CreateStore/#store-dashboard"
+      documentationLabel="Review BTCPay dashboard docs"
+    />
+  );
+}
+
+export default DashboardPage as unknown as () => Promise<ReactElement>;

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/layout.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/layout.tsx
@@ -1,0 +1,145 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { fetchFromBff } from "../../../../../lib/server-api";
+import { Button } from "../../../../../components/ui/button";
+import { StoreLayoutProvider } from "./store-layout-context";
+import { StoreSidebar, StoreSidebarSection } from "./store-sidebar";
+
+interface StoreSettingsResponse {
+  storeId: string;
+  btcpayStoreId: string;
+  storeName: string | null;
+  storeWebsite: string | null;
+  storeKeyLastFour: string | null;
+  btcpayHost: string;
+  walletSetupStatus: string;
+  apiKeyManagedByTenant: boolean;
+}
+
+async function loadStoreSettings(tenantId: string, storeId: string): Promise<StoreSettingsResponse> {
+  const response = await fetchFromBff(`/tenants/${tenantId}/stores/${storeId}`);
+  if (response.status === 404) {
+    notFound();
+  }
+  if (!response.ok) {
+    throw new Error(`Failed to load store settings (${response.status}).`);
+  }
+  return (await response.json()) as StoreSettingsResponse;
+}
+
+function buildStoreSections(tenantId: string, storeId: string): StoreSidebarSection[] {
+  const base = `/tenants/${tenantId}/stores/${storeId}`;
+  return [
+    {
+      title: "Store",
+      items: [
+        { label: "Dashboard", href: `${base}/dashboard` },
+        { label: "Settings", href: `${base}/settings` }
+      ]
+    },
+    {
+      title: "Payments",
+      items: [
+        { label: "Invoices", href: `${base}/payments/invoices` },
+        { label: "Payment Requests", href: `${base}/payments/requests` },
+        { label: "Pull Payments", href: `${base}/payments/pull-payments` },
+        { label: "Reporting", href: `${base}/payments/reporting` }
+      ]
+    },
+    {
+      title: "Checkout & Integrations",
+      items: [{ label: "API Keys", href: `${base}/checkout-integrations/api-keys` }]
+    },
+    {
+      title: "Wallets",
+      items: [{ label: "Bitcoin (On-Chain)", href: `${base}/wallets/bitcoin` }]
+    }
+  ];
+}
+
+function buildStoreLink(host: string, storeId: string): string | null {
+  try {
+    const url = new URL(host);
+    url.pathname = `/stores/${storeId}`;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export default async function StoreLayout({
+  children,
+  params
+}: {
+  children: ReactNode;
+  params: { tenantId: string; storeId: string };
+}) {
+  const { tenantId, storeId } = params;
+  const store = await loadStoreSettings(tenantId, storeId);
+  const sections = buildStoreSections(tenantId, storeId);
+  const btcpayStoreUrl = buildStoreLink(store.btcpayHost, store.btcpayStoreId);
+  const providerValue = {
+    tenantId,
+    storeId,
+    btcpayStoreId: store.btcpayStoreId,
+    btcpayHost: store.btcpayHost,
+    storeName: store.storeName,
+    storeWebsite: store.storeWebsite,
+    storeKeyLastFour: store.storeKeyLastFour,
+    walletSetupStatus: store.walletSetupStatus,
+    apiKeyManagedByTenant: store.apiKeyManagedByTenant
+  } as const;
+
+  return (
+    <StoreLayoutProvider value={providerValue}>
+      <div className="flex flex-col gap-8">
+        <header className="rounded-xl border bg-card p-6 shadow-sm">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="space-y-2">
+              <nav className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Link href={`/tenants/${tenantId}/stores`} className="hover:text-foreground">
+                  Stores
+                </Link>
+                <span>/</span>
+                <span className="text-foreground">{store.storeName ?? store.btcpayStoreId}</span>
+              </nav>
+              <h1 className="text-3xl font-semibold text-foreground">{store.storeName ?? "Unnamed store"}</h1>
+              <p className="text-sm text-muted-foreground">
+                Connected to BTCPay store <span className="font-mono text-foreground">{store.btcpayStoreId}</span> on
+                {" "}
+                <a
+                  href={store.btcpayHost}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline-offset-4 hover:underline"
+                >
+                  {store.btcpayHost}
+                </a>
+                .
+              </p>
+            </div>
+            <div className="flex gap-3">
+              {btcpayStoreUrl && (
+                <Button asChild variant="outline">
+                  <Link href={btcpayStoreUrl} target="_blank" rel="noopener noreferrer">
+                    Open in BTCPay
+                  </Link>
+                </Button>
+              )}
+              <Button asChild>
+                <Link href={`/tenants/${tenantId}/stores/${storeId}/payments/invoices`}>Create invoice</Link>
+              </Button>
+            </div>
+          </div>
+        </header>
+        <div className="grid gap-6 lg:grid-cols-[260px_1fr]">
+          <aside className="rounded-xl border bg-card/60 p-4 shadow-sm">
+            <StoreSidebar sections={sections} />
+          </aside>
+          <section className="min-w-0">{children}</section>
+        </div>
+      </div>
+    </StoreLayoutProvider>
+  );
+}

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/payments/invoices/page.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/payments/invoices/page.tsx
@@ -1,0 +1,15 @@
+import type { ReactElement } from "react";
+import { StoreFeaturePlaceholder } from "../../store-feature-placeholder";
+
+async function InvoicesPage(): Promise<ReactElement> {
+  return (
+    <StoreFeaturePlaceholder
+      title="Invoices"
+      description="Issue, monitor and mark invoices as paid directly from BTCPay while portal analytics are being built."
+      documentationUrl="https://docs.btcpayserver.org/Invoices/"
+      documentationLabel="BTCPay invoices guide"
+    />
+  );
+}
+
+export default InvoicesPage as unknown as () => Promise<ReactElement>;

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/payments/pull-payments/page.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/payments/pull-payments/page.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from "react";
+import { StoreFeaturePlaceholder } from "../../store-feature-placeholder";
+
+async function PullPaymentsPage(): Promise<ReactElement> {
+  return (
+    <StoreFeaturePlaceholder
+      title="Pull Payments & Payouts"
+      description="Configure pull payments, approve payouts and automate disbursements from the BTCPay dashboard while portal
+      workflows are shipping."
+      documentationUrl="https://docs.btcpayserver.org/PullPayments/"
+      documentationLabel="Pull payments & payouts guide"
+    />
+  );
+}
+
+export default PullPaymentsPage as unknown as () => Promise<ReactElement>;

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/payments/reporting/page.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/payments/reporting/page.tsx
@@ -1,0 +1,15 @@
+import type { ReactElement } from "react";
+import { StoreFeaturePlaceholder } from "../../store-feature-placeholder";
+
+async function ReportingPage(): Promise<ReactElement> {
+  return (
+    <StoreFeaturePlaceholder
+      title="Reporting"
+      description="Aggregate invoices, payouts and on-chain activity directly from BTCPay until in-portal analytics are ready."
+      documentationUrl="https://docs.btcpayserver.org/Accounting/"
+      documentationLabel="BTCPay accounting documentation"
+    />
+  );
+}
+
+export default ReportingPage as unknown as () => Promise<ReactElement>;

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/payments/requests/page.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/payments/requests/page.tsx
@@ -1,0 +1,15 @@
+import type { ReactElement } from "react";
+import { StoreFeaturePlaceholder } from "../../store-feature-placeholder";
+
+async function PaymentRequestsPage(): Promise<ReactElement> {
+  return (
+    <StoreFeaturePlaceholder
+      title="Payment Requests"
+      description="Manage long-lived payment requests, reminders and public donation pages using the BTCPay interface."
+      documentationUrl="https://docs.btcpayserver.org/PaymentRequests/"
+      documentationLabel="Payment requests documentation"
+    />
+  );
+}
+
+export default PaymentRequestsPage as unknown as () => Promise<ReactElement>;

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/settings/page.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/settings/page.tsx
@@ -1,46 +1,5 @@
 import type { ReactElement } from "react";
-import { cookies } from "next/headers";
-import { notFound } from "next/navigation";
-import StoreSettingsClient from "./store-settings-client";
-import { getBffApiBaseUrl } from "../../../../../../lib/bff";
-
-interface StoreSettingsResponse {
-  storeId: string;
-  btcpayStoreId: string;
-  storeName: string | null;
-  storeWebsite: string | null;
-  storeKeyLastFour: string | null;
-  apiKeyManagedByTenant: boolean;
-}
-
-async function fetchStoreSettings(tenantId: string, storeId: string): Promise<StoreSettingsResponse> {
-  const baseUrl = getBffApiBaseUrl();
-  const url = `${baseUrl}/tenants/${tenantId}/stores/${storeId}`;
-  const cookieStore = cookies() as unknown as Awaited<ReturnType<typeof cookies>>;
-  const serializedCookies = cookieStore
-    .getAll()
-    .map((cookie) => `${cookie.name}=${cookie.value}`)
-    .join("; ");
-
-  const response = await fetch(url, {
-    method: "GET",
-    cache: "no-store",
-    headers: {
-      Accept: "application/json",
-      ...(serializedCookies ? { Cookie: serializedCookies } : {})
-    }
-  });
-
-  if (response.status === 404) {
-    notFound();
-  }
-
-  if (!response.ok) {
-    throw new Error(`Failed to load store settings (${response.status}).`);
-  }
-
-  return (await response.json()) as StoreSettingsResponse;
-}
+import StoreSettingsContainer from "./store-settings-container";
 
 type StoreSettingsPageParams = {
   tenantId: string;
@@ -53,9 +12,7 @@ async function StoreSettingsPage({
   params: StoreSettingsPageParams;
 }) {
   const { tenantId, storeId } = params;
-  const initialData = await fetchStoreSettings(tenantId, storeId);
-
-  return <StoreSettingsClient tenantId={tenantId} storeId={storeId} initialData={initialData} />;
+  return <StoreSettingsContainer tenantId={tenantId} storeId={storeId} />;
 }
 
 export default StoreSettingsPage as unknown as (props: any) => Promise<ReactElement>;

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/settings/store-settings-client.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/settings/store-settings-client.tsx
@@ -11,6 +11,8 @@ interface StoreSettingsData {
   storeName: string | null;
   storeWebsite: string | null;
   storeKeyLastFour: string | null;
+  btcpayHost: string;
+  walletSetupStatus: string;
   apiKeyManagedByTenant: boolean;
 }
 
@@ -116,7 +118,7 @@ export default function StoreSettingsClient({
             {status}
           </div>
         )}
-        <dl className="grid gap-4 md:grid-cols-2">
+        <dl className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           <div className="rounded-lg border bg-background px-4 py-3">
             <dt className="text-xs uppercase tracking-wide text-muted-foreground">BTCPay Store ID</dt>
             <dd className="mt-1 font-medium text-sm text-foreground break-words">{data.btcpayStoreId}</dd>
@@ -143,6 +145,23 @@ export default function StoreSettingsClient({
                 "Not set"
               )}
             </dd>
+          </div>
+          <div className="rounded-lg border bg-background px-4 py-3">
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">BTCPay Host</dt>
+            <dd className="mt-1 text-sm font-medium text-foreground">
+              <a
+                href={data.btcpayHost}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary underline-offset-4 hover:underline break-words"
+              >
+                {data.btcpayHost}
+              </a>
+            </dd>
+          </div>
+          <div className="rounded-lg border bg-background px-4 py-3">
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">Wallet setup</dt>
+            <dd className="mt-1 text-sm font-medium text-foreground">{formatWalletStatus(data.walletSetupStatus)}</dd>
           </div>
           <div className="rounded-lg border bg-background px-4 py-3">
             <dt className="text-xs uppercase tracking-wide text-muted-foreground">Store API key</dt>
@@ -191,4 +210,18 @@ function resolveActionError(error: unknown, fallback: string): string {
   }
 
   return fallback;
+}
+
+function formatWalletStatus(status: string): string {
+  const normalized = status.trim().toLowerCase();
+  switch (normalized) {
+    case "ready":
+      return "Ready";
+    case "pending":
+      return "Pending setup";
+    case "disabled":
+      return "Disabled";
+    default:
+      return status;
+  }
 }

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/settings/store-settings-container.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/settings/store-settings-container.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import StoreSettingsClient from "./store-settings-client";
+import { useStoreLayout } from "../store-layout-context";
+
+interface StoreSettingsContainerProps {
+  tenantId: string;
+  storeId: string;
+}
+
+export default function StoreSettingsContainer({ tenantId, storeId }: StoreSettingsContainerProps) {
+  const store = useStoreLayout();
+
+  return (
+    <StoreSettingsClient
+      tenantId={tenantId}
+      storeId={storeId}
+      initialData={{
+        storeId,
+        btcpayStoreId: store.btcpayStoreId,
+        storeName: store.storeName,
+        storeWebsite: store.storeWebsite,
+        storeKeyLastFour: store.storeKeyLastFour,
+        apiKeyManagedByTenant: store.apiKeyManagedByTenant,
+        btcpayHost: store.btcpayHost,
+        walletSetupStatus: store.walletSetupStatus
+      }}
+    />
+  );
+}

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/store-feature-placeholder.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/store-feature-placeholder.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "../../../../../components/ui/button";
+import { useStoreLayout } from "./store-layout-context";
+
+interface StoreFeaturePlaceholderProps {
+  title: string;
+  description: string;
+  documentationUrl: string;
+  documentationLabel?: string;
+}
+
+export function StoreFeaturePlaceholder({
+  title,
+  description,
+  documentationUrl,
+  documentationLabel = "Open documentation"
+}: StoreFeaturePlaceholderProps) {
+  const store = useStoreLayout();
+  const displayName = store.storeName ?? store.btcpayStoreId;
+
+  return (
+    <section className="rounded-xl border bg-card p-6 shadow-sm">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">{title}</h1>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </header>
+      <div className="mt-6 rounded-lg border bg-background px-4 py-3 text-sm text-muted-foreground">
+        {displayName} remains fully operational through BTCPay Server while this portal experience is under active development.
+        Follow the official guide below to manage the feature directly inside BTCPay.
+      </div>
+      <Button asChild className="mt-6" variant="outline">
+        <Link href={documentationUrl} target="_blank" rel="noopener noreferrer">
+          {documentationLabel}
+        </Link>
+      </Button>
+    </section>
+  );
+}

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/store-layout-context.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/store-layout-context.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { createContext, ReactNode, useContext } from "react";
+
+export interface StoreLayoutContextValue {
+  tenantId: string;
+  storeId: string;
+  btcpayStoreId: string;
+  btcpayHost: string;
+  storeName: string | null;
+  storeWebsite: string | null;
+  storeKeyLastFour: string | null;
+  walletSetupStatus: string;
+  apiKeyManagedByTenant: boolean;
+}
+
+const StoreLayoutContext = createContext<StoreLayoutContextValue | null>(null);
+
+export function StoreLayoutProvider({
+  value,
+  children
+}: {
+  value: StoreLayoutContextValue;
+  children: ReactNode;
+}) {
+  return <StoreLayoutContext.Provider value={value}>{children}</StoreLayoutContext.Provider>;
+}
+
+export function useStoreLayout(): StoreLayoutContextValue {
+  const context = useContext(StoreLayoutContext);
+  if (!context) {
+    throw new Error("useStoreLayout must be used within a StoreLayoutProvider");
+  }
+  return context;
+}

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/store-sidebar.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/store-sidebar.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export interface StoreSidebarItem {
+  label: string;
+  href: string;
+}
+
+export interface StoreSidebarSection {
+  title: string;
+  items: StoreSidebarItem[];
+}
+
+export function StoreSidebar({ sections }: { sections: StoreSidebarSection[] }) {
+  const pathname = usePathname();
+
+  const isActive = (href: string) => {
+    if (!pathname) {
+      return false;
+    }
+    if (pathname === href) {
+      return true;
+    }
+    return pathname.startsWith(`${href}/`);
+  };
+
+  return (
+    <nav className="space-y-6">
+      {sections.map((section) => (
+        <div key={section.title} className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {section.title}
+          </p>
+          <ul className="space-y-1">
+            {section.items.map((item) => {
+              const active = isActive(item.href);
+              return (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    className={`block rounded-md px-3 py-2 text-sm transition-colors ${
+                      active
+                        ? "bg-primary text-primary-foreground shadow-sm"
+                        : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                    }`}
+                  >
+                    {item.label}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  );
+}

--- a/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/wallets/bitcoin/page.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/[storeId]/wallets/bitcoin/page.tsx
@@ -1,0 +1,15 @@
+import type { ReactElement } from "react";
+import { StoreFeaturePlaceholder } from "../../store-feature-placeholder";
+
+async function BitcoinWalletPage(): Promise<ReactElement> {
+  return (
+    <StoreFeaturePlaceholder
+      title="Bitcoin Wallet"
+      description="Connect your on-chain wallet, review balances and manage derivation schemes directly from the BTCPay wallet UI."
+      documentationUrl="https://docs.btcpayserver.org/WalletSetup/"
+      documentationLabel="BTCPay wallet setup guide"
+    />
+  );
+}
+
+export default BitcoinWalletPage as unknown as () => Promise<ReactElement>;

--- a/apps/frontend/app/tenants/[tenantId]/stores/page.tsx
+++ b/apps/frontend/app/tenants/[tenantId]/stores/page.tsx
@@ -1,0 +1,141 @@
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { fetchFromBff } from "../../../../lib/server-api";
+import { Button } from "../../../../components/ui/button";
+
+interface TenantStoreSummary {
+  storeId: string;
+  btcpayStoreId: string;
+  storeName: string | null;
+  storeWebsite: string | null;
+  storeKeyLastFour: string | null;
+  btcpayHost: string;
+  walletSetupStatus: string;
+  apiKeyManagedByTenant: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+async function fetchStores(tenantId: string): Promise<TenantStoreSummary[]> {
+  const response = await fetchFromBff(`/tenants/${tenantId}/stores`);
+  if (!response.ok) {
+    throw new Error(`Failed to load stores (${response.status}).`);
+  }
+  const payload = (await response.json()) as TenantStoreSummary[];
+  if (!Array.isArray(payload)) {
+    return [];
+  }
+  return payload;
+}
+
+type StoresPageParams = {
+  tenantId: string;
+};
+
+async function StoresPage({ params }: { params: StoresPageParams }): Promise<ReactElement> {
+  const { tenantId } = params;
+  const stores = await fetchStores(tenantId);
+
+  return (
+    <div className="flex flex-col gap-8">
+      <section className="rounded-xl border bg-card p-6 shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-semibold">Stores</h1>
+            <p className="text-sm text-muted-foreground">
+              Manage BTCPay stores linked to your organization. Each store is provisioned with a scoped Greenfield API key and
+              webhook registered by the backend.
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 md:flex-row">
+            <Button asChild>
+              <Link href={`/tenants/${tenantId}/stores/create`}>Create store</Link>
+            </Button>
+            <Button asChild variant="outline">
+              <Link href="https://docs.btcpayserver.org/CreateStore/" target="_blank" rel="noopener noreferrer">
+                Open BTCPay guide
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      {stores.length === 0 ? (
+        <section className="rounded-xl border border-dashed bg-muted/30 p-12 text-center shadow-sm">
+          <h2 className="text-xl font-semibold">No stores yet</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Create your first store to generate invoices, configure payment requests and connect wallets through the BTCPay
+            Greenfield API.
+          </p>
+          <Button asChild className="mt-6">
+            <Link href={`/tenants/${tenantId}/stores/create`}>Create BTCPay store</Link>
+          </Button>
+        </section>
+      ) : (
+        <section className="grid gap-4 lg:grid-cols-2">
+          {stores.map((store) => {
+            const displayName = store.storeName?.trim().length ? store.storeName : "Unnamed store";
+            const maskedKey = store.storeKeyLastFour ? `****${store.storeKeyLastFour}` : "Unavailable";
+            return (
+              <article key={store.storeId} className="rounded-xl border bg-card p-6 shadow-sm">
+                <header className="space-y-1">
+                  <h2 className="text-xl font-semibold text-foreground">{displayName}</h2>
+                  <p className="text-sm text-muted-foreground">
+                    Store ID <span className="font-mono text-foreground">{store.btcpayStoreId}</span>
+                  </p>
+                </header>
+                <dl className="mt-4 space-y-2 text-sm text-muted-foreground">
+                  <div className="flex justify-between gap-3">
+                    <dt className="font-medium text-foreground">BTCPay host</dt>
+                    <dd className="text-right">
+                      <a
+                        href={store.btcpayHost}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary underline-offset-4 hover:underline"
+                      >
+                        {store.btcpayHost}
+                      </a>
+                    </dd>
+                  </div>
+                  <div className="flex justify-between gap-3">
+                    <dt className="font-medium text-foreground">API key</dt>
+                    <dd className="text-right font-mono text-foreground">{maskedKey}</dd>
+                  </div>
+                  <div className="flex justify-between gap-3">
+                    <dt className="font-medium text-foreground">Wallet setup</dt>
+                    <dd className="text-right text-foreground">{formatWalletStatus(store.walletSetupStatus)}</dd>
+                  </div>
+                </dl>
+                <div className="mt-6 flex flex-wrap gap-3">
+                  <Button asChild>
+                    <Link href={`/tenants/${tenantId}/stores/${store.storeId}/dashboard`}>Open store</Link>
+                  </Button>
+                  <Button asChild variant="outline">
+                    <Link href={`/tenants/${tenantId}/stores/${store.storeId}/settings`}>View settings</Link>
+                  </Button>
+                </div>
+              </article>
+            );
+          })}
+        </section>
+      )}
+    </div>
+  );
+}
+
+export default StoresPage as unknown as (props: { params: StoresPageParams }) => Promise<ReactElement>;
+
+function formatWalletStatus(status: string): string {
+  const normalized = status.trim().toLowerCase();
+  switch (normalized) {
+    case "ready":
+      return "Ready";
+    case "pending":
+      return "Pending setup";
+    case "disabled":
+      return "Disabled";
+    default:
+      return status;
+  }
+}

--- a/apps/frontend/lib/server-api.ts
+++ b/apps/frontend/lib/server-api.ts
@@ -1,0 +1,33 @@
+import { cookies } from "next/headers";
+import { getBffApiBaseUrl } from "./bff";
+
+function normalizePath(path: string): string {
+  if (!path.startsWith("/")) {
+    return `/${path}`;
+  }
+  return path;
+}
+
+export async function fetchFromBff(path: string, init: RequestInit = {}): Promise<Response> {
+  const baseUrl = getBffApiBaseUrl();
+  const url = `${baseUrl}${normalizePath(path)}`;
+  const cookieStore = await cookies();
+  const serializedCookies = cookieStore
+    .getAll()
+    .map((cookie) => `${cookie.name}=${cookie.value}`)
+    .join("; ");
+
+  const headers = new Headers(init.headers ?? {});
+  if (serializedCookies && !headers.has("cookie") && !headers.has("Cookie")) {
+    headers.set("Cookie", serializedCookies);
+  }
+  if (!headers.has("accept") && !headers.has("Accept")) {
+    headers.set("Accept", "application/json");
+  }
+
+  return fetch(url, {
+    ...init,
+    cache: init.cache ?? "no-store",
+    headers
+  });
+}


### PR DESCRIPTION
## Summary
- expose a tenant-scoped store listing endpoint with normalized metadata
- add a reusable server fetch helper and portal layout with BTCPay-inspired store navigation
- implement tenant store index, settings enhancements, and feature placeholders linked to BTCPay docs

## Testing
- pnpm --filter bff build
- pnpm --filter frontend typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e3a440049c832f937cd98c63c969b8