### PR TITLE
Ensure wallet presence updates immediately

### DIFF
--- a/apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/_lib/get-wallet-presence.test.ts
+++ b/apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/_lib/get-wallet-presence.test.ts
@@ -48,8 +48,38 @@ describe("getWalletPresence", () => {
     });
     expect(mockFetch).toHaveBeenCalledWith(
       walletPresencePath("store-1"),
-      expect.objectContaining({ cache: "no-store" }),
+      expect.objectContaining({ cache: "no-store", next: { revalidate: 0 } }),
     );
+  });
+
+  it("re-fetches presence instead of serving cached data", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ hasWallet: false }),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ hasWallet: true }),
+      } as unknown as Response);
+
+    await expect(getWalletPresence("store-5")).resolves.toEqual({
+      status: 200,
+      connected: false,
+      hasWallet: false,
+      payload: { hasWallet: false },
+    });
+
+    await expect(getWalletPresence("store-5")).resolves.toEqual({
+      status: 200,
+      connected: true,
+      hasWallet: true,
+      payload: { hasWallet: true },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it("returns false when response is not ok", async () => {

--- a/apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/_lib/get-wallet-presence.ts
+++ b/apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/_lib/get-wallet-presence.ts
@@ -1,5 +1,3 @@
-import { cache } from "react";
-
 import { bffFetch } from "../../../../../../lib/bff-fetch";
 import { walletPresencePath } from "../../../../../../lib/walletPaths";
 
@@ -14,7 +12,7 @@ export interface WalletPresenceResult {
   payload: WalletPresenceResponse | null;
 }
 
-export const getWalletPresence = cache(async (storeId: string): Promise<WalletPresenceResult> => {
+export const getWalletPresence = async (storeId: string): Promise<WalletPresenceResult> => {
   const normalized = typeof storeId === "string" ? storeId.trim() : "";
   if (!normalized) {
     return { status: 400, connected: false, hasWallet: false, payload: null } satisfies WalletPresenceResult;
@@ -23,6 +21,7 @@ export const getWalletPresence = cache(async (storeId: string): Promise<WalletPr
   try {
     const response = await bffFetch(walletPresencePath(normalized), {
       cache: "no-store",
+      next: { revalidate: 0 },
     });
 
     const status = typeof response.status === "number" ? response.status : response.ok ? 200 : 0;
@@ -44,7 +43,7 @@ export const getWalletPresence = cache(async (storeId: string): Promise<WalletPr
   } catch {
     return { status: 0, connected: false, hasWallet: false, payload: null } satisfies WalletPresenceResult;
   }
-});
+};
 
 export function parseWalletPresence(data: unknown): WalletPresenceResponse | null {
   if (!data || typeof data !== "object" || Array.isArray(data)) {

--- a/apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/wallets/btc/wizard/page.tsx
+++ b/apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/wallets/btc/wizard/page.tsx
@@ -11,6 +11,7 @@ import { getCsrfToken } from "../../../../../../../../lib/auth";
 import { CSRF_HEADER } from "../../../../../../../../lib/http-headers";
 import { useToast } from "../../../../../../../../components/ui/toast";
 import { bffFetch } from "../../../../../../../../lib/bff-fetch";
+import { useWalletPresence } from "../../../../../../../../src/contexts/wallet-presence";
 import { detectNetworkFromInput, importWalletSchema, resolveInstanceNetwork } from "./validation";
 
 type WizardStep = "connect" | "enter" | "confirm";
@@ -203,6 +204,7 @@ export default function WalletWizardPage({ params }: WizardProps) {
   const { storeId } = use(params);
   const router = useRouter();
   const toastContext = useToast();
+  const { refresh: refreshWalletPresence } = useWalletPresence();
 
   const [step, setStep] = useState<WizardStep>("connect");
   const [importInput, setImportInput] = useState<{ tpub: string; rootFingerprint: string; accountKeyPath: string }>(() => ({
@@ -365,6 +367,7 @@ export default function WalletWizardPage({ params }: WizardProps) {
         body: payload,
         headers: { "Content-Type": "application/json", [CSRF_HEADER]: csrfToken },
       });
+      await refreshWalletPresence();
       toastContext.toast({
         title: "Wallet connected",
         description: "The on-chain Bitcoin wallet has been saved for this store.",
@@ -389,7 +392,7 @@ export default function WalletWizardPage({ params }: WizardProps) {
     } finally {
       setIsLoading(false);
     }
-  }, [importInput, isLoading, preview, router, storeId, toastContext]);
+  }, [importInput, isLoading, preview, refreshWalletPresence, router, storeId, toastContext]);
 
   const handleBackToEnter = useCallback(() => {
     setStep("enter");


### PR DESCRIPTION
## Summary
- remove React cache usage and enforce no-store fetching for wallet presence checks
- re-fetch wallet presence after completing the Bitcoin wallet wizard so navigation appears instantly
- expand wallet presence tests to cover cache bypassing and request options

## Testing
- pnpm exec vitest run "app/(dashboard)/(stores)/stores/[storeId]/_lib/get-wallet-presence.test.ts"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692368c29868832f84a9a3001bf191d1)