### PR TITLE
Add BTC receive address support

### DIFF
--- a/.agent/execplans/btc-receive.md
+++ b/.agent/execplans/btc-receive.md
@@ -1,0 +1,69 @@
+# Implement BTC Receive UX and BFF endpoints
+
+This ExecPlan is a living document. Maintain it according to .agent/PLANS.md.
+
+## Purpose / Big Picture
+
+Enable merchants to view and generate BTC on-chain receive addresses within the dashboard, mirroring BTCPay Server’s Receive UX while keeping API keys confined to the BFF. After implementation, a user can open Bitcoin → Receive, view the next receive address or BIP21 link with QR, copy it, generate a new address, and inspect reserved addresses backed by official BTCPay Greenfield wallet endpoints.
+
+## Progress
+
+- [x] (2024-06-06 00:00Z) Drafted ExecPlan outlining BFF endpoints, frontend UI/UX, hooks, and tests for BTC Receive.
+- [x] (2024-06-06 01:00Z) Implemented BFF wallet service methods for next receive address and reserved addresses using Greenfield endpoints with error masking.
+- [x] (2024-06-06 01:05Z) Exposed receive endpoints in BitcoinWalletActionsController with guard and parameter handling.
+- [x] (2024-06-06 01:40Z) Built frontend Receive page UI (Address/Link toggle, QR, copy, labels placeholder, generate and reserved views) using new hooks.
+- [x] (2024-06-06 01:40Z) Implemented hooks for fetching next address and reserved addresses with loading/error handling.
+- [x] (2024-06-06 01:50Z) Added tests for Receive component interactions and data loading.
+- [x] (2024-06-06 02:10Z) Ran frontend test suite with targeted receive coverage (full suite has existing flaky wallet-actions-menu test).
+
+## Surprises & Discoveries
+
+- None yet.
+
+## Decision Log
+
+- None yet.
+
+## Outcomes & Retrospective
+
+- To be filled after implementation and validation.
+
+## Context and Orientation
+
+Repository is a monorepo with BFF (NestJS) in apps/bff and frontend (Next.js/React) in apps/frontend. Wallet interactions live under apps/bff/src/btcpay and apps/bff/src/wallets. Frontend wallet pages under apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/wallets. Existing wallet hooks likely under apps/frontend/lib or similar (review existing Send/Transactions hooks for patterns). We must use BTCPay Greenfield v1 Store On-Chain Wallets endpoints to fetch/generate receive addresses and list reserved addresses, using store-scoped API keys already available via ManagedStoreEntity and BtcpayService. Error handling uses maskError utility mapping BTCPay HTTP status codes to Nest exceptions. Frontend uses React Query (or similar) for data fetching; mirror existing hook approach. No API keys or secrets may leak to frontend.
+
+## Plan of Work
+
+Expand btcpay.wallets.service.ts with interfaces and methods for receive: getNextReceiveAddress handling optional forceGenerate flag, mapping Greenfield response to address/paymentLink/reservedAt/isPayjoinEnabled fields, and listReservedAddresses returning address listings. Use BtcpayService HTTP client and maskError. Extend bitcoin-wallet-actions.controller.ts to add receive/next and receive/reserved GET routes leveraging existing guards/store resolution and new service methods, normalizing walletCode and parsing query params with defaults. On frontend, replace placeholder receive page with client component that displays header, Address/Link toggle, QR code derived from address/paymentLink, copy controls, labels placeholder, generate button calling forceGenerate, and Reserved Addresses view/table toggled via state or navigation. Implement hooks useBtcReceiveAddress and useBtcReservedAddresses following existing wallet hook patterns and calling new BFF endpoints. Add UI states for loading/error/no-wallet (404) and auth errors. Provide basic tests for component rendering, toggle behavior, data fetch, and generate action invocation.
+
+## Concrete Steps
+
+1. Inspect existing BtcpayWalletsService, error handling, and controller patterns in apps/bff to align with current conventions.
+2. Implement interface and methods in apps/bff/src/btcpay/btcpay.wallets.service.ts for getNextReceiveAddress and listReservedAddresses using Greenfield Store On-Chain Wallet endpoints (get address, list addresses). Map response fields and use maskError for errors.
+3. Update apps/bff/src/wallets/bitcoin-wallet-actions.controller.ts to add GET /receive/next and /receive/reserved endpoints with guards, store resolution, walletCode normalization, and query parsing (forceGenerate, take default 25, skip default 0). Return shaped JSON as specified.
+4. Identify frontend hook patterns (likely in apps/frontend/lib/hooks or similar). Add hooks useBtcReceiveAddress and useBtcReservedAddresses that call the new BFF routes and expose loading/error/refetch.
+5. Replace placeholder receive page in apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/wallets/btc/receive with real UI using a client component. Include Address/Link toggle, QR code (reuse existing QR component if available or lightweight dependency), copy buttons, labels placeholder select (disabled), generate another address button (forceGenerate), and Reserved Addresses view/table with loading/empty/error states and navigation between current/reserved views.
+6. Add frontend tests for Receive component verifying header render, loading behavior, toggle changes displayed text, and generate button triggers fetch/mock client. Include reserved addresses loading where applicable.
+7. Run lint/tests (e.g., pnpm lint/test) or targeted commands to ensure consistency.
+
+## Validation and Acceptance
+
+- BFF endpoints return mapped address and reserved address data without leaking secrets; getNextReceiveAddress supports forceGenerate=true to reserve a new address. Masked errors behave consistently (401/403→Unauthorized, 404→NotFound).
+- Frontend Receive page loads next address on mount, displays QR and address/payment link with copy actions, toggles between Address and Link, supports generating another address to refresh data, and navigates to reserved addresses view showing a table or empty state with retry handling.
+- Tests for Receive component pass, demonstrating header, toggle, data fetch, and generate action behaviors. Repository lint/tests succeed.
+
+## Idempotence and Recovery
+
+Changes are additive. Re-running service methods or hooks is safe as they are read actions; forceGenerate explicitly requests a new address. If an endpoint call fails, maskError ensures consistent exceptions; frontend shows error states with retry/refetch. Git changes can be reset via git checkout if needed.
+
+## Artifacts and Notes
+
+None yet.
+
+## Interfaces and Dependencies
+
+- apps/bff/src/btcpay/btcpay.wallets.service.ts: add interface { address: string; paymentLink: string; reservedAt?: string; isPayjoinEnabled?: boolean } and methods getNextReceiveAddress(options: { store: ManagedStoreEntity; walletCode: string; forceGenerate?: boolean }) and listReservedAddresses(options: { store: ManagedStoreEntity; walletCode: string; take?: number; skip?: number }). Use BtcpayService client, Greenfield Store On-Chain Wallet endpoints (get address, list addresses), map fields, and maskError.
+- apps/bff/src/wallets/bitcoin-wallet-actions.controller.ts: add GET receive/next and receive/reserved routes returning mapped data, using existing guards and store resolution.
+- Frontend hooks (path matching existing wallet hooks) useBtcReceiveAddress(storeId) and useBtcReservedAddresses(storeId, opts) calling new endpoints.
+- Frontend Receive page components under apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/wallets/btc/receive: render UI with toggle, QR (use existing QR component or lightweight addition), copy buttons, labels placeholder, generate, reserved addresses view/table.
+- Tests under frontend test suite (e.g., apps/frontend/__tests__ or similar) covering UI interactions and fetches.

--- a/apps/bff/src/btcpay/btcpay.wallets.service.ts
+++ b/apps/bff/src/btcpay/btcpay.wallets.service.ts
@@ -36,6 +36,32 @@ export interface ListTransactionsResult {
   items: unknown[];
 }
 
+export interface WalletReceiveAddress {
+  address: string;
+  paymentLink: string;
+  reservedAt?: string;
+  isPayjoinEnabled?: boolean;
+}
+
+export interface WalletReservedAddress {
+  address: string;
+  label?: string;
+  reservedAt?: string;
+}
+
+interface ReceiveAddressOptions {
+  store: ManagedStoreEntity;
+  walletCode: string;
+  forceGenerate?: boolean;
+}
+
+interface ListReservedAddressesOptions {
+  store: ManagedStoreEntity;
+  walletCode: string;
+  take?: number;
+  skip?: number;
+}
+
 interface StoreContext {
   store: ManagedStoreEntity;
   apiKey: string;
@@ -211,6 +237,59 @@ export class BtcpayWalletService {
     throw new InternalServerErrorException('Failed to load on-chain receive address.');
   }
 
+  async getNextReceiveAddress(options: ReceiveAddressOptions): Promise<WalletReceiveAddress> {
+    const walletCode = this.normalizeCryptoCode(options.walletCode);
+    const context = await this.prepareStoreContext(options.store.btcpayStoreId ?? options.store.id, {
+      store: options.store
+    });
+
+    const params = options.forceGenerate ? { forceGenerate: true } : undefined;
+
+    try {
+      const response = await context.http.get(
+        this.buildAddressPath(context.store.btcpayStoreId ?? context.store.id, walletCode),
+        params ? { params } : undefined
+      );
+      return this.normalizeReceiveAddressResponse(response.data);
+    } catch (error) {
+      this.handleBtcpayError(error);
+    } finally {
+      context.cleanup();
+    }
+
+    throw new InternalServerErrorException('Failed to load on-chain receive address.');
+  }
+
+  async listReservedAddresses(
+    options: ListReservedAddressesOptions
+  ): Promise<{ items: WalletReservedAddress[]; total?: number }> {
+    const walletCode = this.normalizeCryptoCode(options.walletCode);
+    const context = await this.prepareStoreContext(options.store.btcpayStoreId ?? options.store.id, {
+      store: options.store
+    });
+
+    const params = { type: 'address', includeNeighbourData: false } as const;
+
+    try {
+      const response = await context.http.get(
+        this.buildWalletObjectsPath(context.store.btcpayStoreId ?? context.store.id, walletCode),
+        { params }
+      );
+      const normalized = this.normalizeReservedAddressesResponse(response.data);
+      const skip = this.normalizeNonNegativeInt(options.skip, 0);
+      const take = options.take ? this.normalizePositiveInt(options.take, normalized.items.length || 25) : null;
+      const items = take ? normalized.items.slice(skip, skip + take) : normalized.items.slice(skip);
+      const total = normalized.total ?? normalized.items.length;
+      return { items, total };
+    } catch (error) {
+      this.handleBtcpayError(error);
+    } finally {
+      context.cleanup();
+    }
+
+    throw new InternalServerErrorException('Failed to list reserved on-chain addresses.');
+  }
+
   /**
    * Prunes historical transactions without affecting current wallet state.
    * Operation: StoreOnChainWallets_PruneOnChainWalletTransactions
@@ -312,6 +391,122 @@ export class BtcpayWalletService {
     }
 
     throw new InternalServerErrorException('Failed to load on-chain fee rate.');
+  }
+
+  private normalizeReceiveAddressResponse(payload: unknown): WalletReceiveAddress {
+    if (!payload || typeof payload !== 'object') {
+      throw new InternalServerErrorException('BTCPay returned an invalid receive address payload.');
+    }
+
+    const record = payload as Record<string, unknown>;
+    const address = typeof record.address === 'string' ? record.address.trim() : '';
+    const paymentLink = typeof record.paymentLink === 'string' ? record.paymentLink.trim() : null;
+    const reservedAt = typeof record.reservedAt === 'string' ? record.reservedAt.trim() : undefined;
+    const isPayjoinEnabled =
+      typeof record.isPayjoinEnabled === 'boolean'
+        ? record.isPayjoinEnabled
+        : typeof record.payjoinEnabled === 'boolean'
+          ? record.payjoinEnabled
+          : undefined;
+
+    if (!address) {
+      throw new InternalServerErrorException('BTCPay returned a receive address without address details.');
+    }
+
+    const link = paymentLink && paymentLink.toLowerCase().startsWith('bitcoin:') ? paymentLink : `bitcoin:${address}`;
+
+    return {
+      address,
+      paymentLink: link,
+      reservedAt: reservedAt || undefined,
+      isPayjoinEnabled: isPayjoinEnabled ?? undefined
+    } satisfies WalletReceiveAddress;
+  }
+
+  private normalizeNonNegativeInt(value: number | undefined, fallback: number): number {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return Math.max(0, Math.trunc(value));
+    }
+    return fallback;
+  }
+
+  private normalizePositiveInt(value: number | undefined, fallback: number): number {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return Math.max(1, Math.trunc(value));
+    }
+    return fallback;
+  }
+
+  private normalizeReservedAddressesResponse(payload: unknown): {
+    items: WalletReservedAddress[];
+    total?: number;
+  } {
+    if (!payload) {
+      return { items: [] };
+    }
+
+    if (Array.isArray(payload)) {
+      const items = payload
+        .map((entry) => this.normalizeReservedAddressEntry(entry))
+        .filter((entry): entry is WalletReservedAddress => entry !== null);
+      return { items, total: payload.length };
+    }
+
+    if (typeof payload === 'object') {
+      const record = payload as Record<string, unknown>;
+      const data = record.data;
+      const itemsSource = Array.isArray(data) ? data : Array.isArray(record.items) ? record.items : [];
+      const items = itemsSource
+        .map((entry) => this.normalizeReservedAddressEntry(entry))
+        .filter((entry): entry is WalletReservedAddress => entry !== null);
+      const totalValue = record.total;
+      const total = typeof totalValue === 'number' && Number.isFinite(totalValue) ? totalValue : undefined;
+      return { items, total };
+    }
+
+    return { items: [] };
+  }
+
+  private normalizeReservedAddressEntry(payload: unknown): WalletReservedAddress | null {
+    if (!payload || typeof payload !== 'object') {
+      return null;
+    }
+
+    const record = payload as Record<string, unknown>;
+    const data = record.data && typeof record.data === 'object' ? (record.data as Record<string, unknown>) : {};
+
+    const addressCandidates = [
+      typeof data.address === 'string' ? data.address.trim() : null,
+      typeof record.id === 'string' ? record.id.trim() : null
+    ].filter((value): value is string => !!value);
+
+    const address = addressCandidates.find((value) => value.length > 0);
+    if (!address) {
+      return null;
+    }
+
+    const label = typeof data.label === 'string' && data.label.trim() ? data.label.trim() : undefined;
+    const reservedAt = this.extractTimestamp(data);
+
+    return { address, label, reservedAt } satisfies WalletReservedAddress;
+  }
+
+  private extractTimestamp(record: Record<string, unknown>): string | undefined {
+    const candidates = [
+      record.reservedAt,
+      record.createdAt,
+      record.creationTime,
+      record.timestamp,
+      record.date
+    ];
+
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim()) {
+        return candidate.trim();
+      }
+    }
+
+    return undefined;
   }
 
   private buildTransactionsQuery(query: ListTransactionsQuery | undefined):
@@ -648,6 +843,10 @@ export class BtcpayWalletService {
     return `${this.buildWalletBasePath(storeId, cryptoCode)}/address`;
   }
 
+  private buildWalletObjectsPath(storeId: string, cryptoCode: string): string {
+    return `${this.buildWalletBasePath(storeId, cryptoCode)}/objects`;
+  }
+
   private buildFeeRatePath(storeId: string, cryptoCode: string): string {
     return `${this.buildWalletBasePath(storeId, cryptoCode)}/feerate`;
   }
@@ -680,17 +879,4 @@ export class BtcpayWalletService {
     }
   }
 
-  private normalizeNonNegativeInt(value: number | undefined, fallback: number): number {
-    if (typeof value !== 'number' || !Number.isFinite(value)) {
-      return fallback;
-    }
-    return Math.max(0, Math.trunc(value));
-  }
-
-  private normalizePositiveInt(value: number | undefined, fallback: number): number {
-    if (typeof value !== 'number' || !Number.isFinite(value)) {
-      return fallback;
-    }
-    return Math.max(1, Math.trunc(value));
-  }
 }

--- a/apps/bff/src/wallets/bitcoin-wallet-actions.controller.ts
+++ b/apps/bff/src/wallets/bitcoin-wallet-actions.controller.ts
@@ -7,6 +7,7 @@ import {
   NotFoundException,
   Param,
   Post,
+  Query,
   UnauthorizedException,
   UseGuards,
   ValidationPipe
@@ -86,6 +87,53 @@ export class BitcoinWalletActionsController {
     return { actions: [...ACTIONS] } satisfies BitcoinWalletActionsResponse;
   }
 
+  @SkipThrottle()
+  @Get('receive/next')
+  @Header('Cache-Control', 'no-store')
+  @Header('Pragma', 'no-cache')
+  @Header('Vary', 'Cookie')
+  async getNextReceiveAddress(
+    @ReqUser() user: RequestUser,
+    @Param('storeId') storeId: string,
+    @Param('walletCode') walletCode: string,
+    @Query('forceGenerate') forceGenerate?: boolean | string
+  ) {
+    const store = await this.requireStore(user, storeId);
+    const normalizedWalletCode = this.normalizeWalletCode(walletCode).toUpperCase();
+    const shouldForceGenerate = this.parseBooleanQuery(forceGenerate);
+
+    return this.btcpayWallets.getNextReceiveAddress({
+      store,
+      walletCode: normalizedWalletCode,
+      forceGenerate: shouldForceGenerate
+    });
+  }
+
+  @SkipThrottle()
+  @Get('receive/reserved')
+  @Header('Cache-Control', 'no-store')
+  @Header('Pragma', 'no-cache')
+  @Header('Vary', 'Cookie')
+  async listReservedAddresses(
+    @ReqUser() user: RequestUser,
+    @Param('storeId') storeId: string,
+    @Param('walletCode') walletCode: string,
+    @Query('take') take?: number | string,
+    @Query('skip') skip?: number | string
+  ) {
+    const store = await this.requireStore(user, storeId);
+    const normalizedWalletCode = this.normalizeWalletCode(walletCode).toUpperCase();
+    const normalizedTake = this.parsePositiveInt(take, 25);
+    const normalizedSkip = this.parseNonNegativeInt(skip, 0);
+
+    return this.btcpayWallets.listReservedAddresses({
+      store,
+      walletCode: normalizedWalletCode,
+      take: normalizedTake,
+      skip: normalizedSkip
+    });
+  }
+
   @Throttle({ default: { limit: 10, ttl: seconds(60) } })
   @HttpCode(200)
   @Post('prune-history')
@@ -144,6 +192,43 @@ export class BitcoinWalletActionsController {
     const normalizedWalletCode = this.normalizeWalletCode(walletCode);
     await this.btcpayWallets.removeWallet(store.btcpayStoreId ?? store.id, normalizedWalletCode, { store });
     return { removed: true } as const;
+  }
+
+  private parseBooleanQuery(value: string | boolean | null | undefined): boolean {
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    if (typeof value !== 'string') {
+      return false;
+    }
+    const normalized = value.trim().toLowerCase();
+    return normalized === 'true' || normalized === '1' || normalized === 'yes';
+  }
+
+  private parseNonNegativeInt(value: string | number | undefined, fallback: number): number {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return Math.max(0, Math.trunc(value));
+    }
+    if (typeof value === 'string') {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return Math.max(0, Math.trunc(parsed));
+      }
+    }
+    return fallback;
+  }
+
+  private parsePositiveInt(value: string | number | undefined, fallback: number): number {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return Math.max(1, Math.trunc(value));
+    }
+    if (typeof value === 'string') {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return Math.max(1, Math.trunc(parsed));
+      }
+    }
+    return fallback;
   }
 
   private async requireStore(user: RequestUser, storeId: string): Promise<ManagedStoreEntity> {

--- a/apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/wallets/btc/receive/page.tsx
+++ b/apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/wallets/btc/receive/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
-import { Card, CardContent, CardHeader, CardTitle } from "../../../../../../../../components/ui/card";
 import { getWalletPresence } from "@/app/(dashboard)/(stores)/stores/[storeId]/_lib/get-wallet-presence";
 import type { WalletPresenceResult } from "@/app/(dashboard)/(stores)/stores/[storeId]/_lib/get-wallet-presence";
+import { ReceiveClient } from "./receive-client";
 
 export const metadata: Metadata = {
   title: "BTC wallet receive",
@@ -13,7 +13,7 @@ type PageProps = {
   params: Promise<{ storeId: string }>;
 };
 
-export default async function WalletReceivePlaceholder({ params }: PageProps) {
+export default async function WalletReceivePage({ params }: PageProps) {
   const { storeId } = await params;
   const normalizedStoreId = typeof storeId === "string" ? storeId.trim() : "";
 
@@ -36,14 +36,7 @@ export default async function WalletReceivePlaceholder({ params }: PageProps) {
     redirect(dashboardPath);
   }
 
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Receive (coming soon)</CardTitle>
-      </CardHeader>
-      <CardContent className="text-sm text-muted-foreground">
-        This section will show your next on-chain receiving address and QR codes once the feature is available.
-      </CardContent>
-    </Card>
-  );
+  const hasWallet = presence.status === 200 ? presence.hasWallet : false;
+
+  return <ReceiveClient storeId={normalizedStoreId} hasWallet={hasWallet} />;
 }

--- a/apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/wallets/btc/receive/receive-client.test.tsx
+++ b/apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/wallets/btc/receive/receive-client.test.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { ToastProvider } from "../../../../../../../../components/ui/toast";
+import { ReceiveClient } from "./receive-client";
+
+const mockUseReceive = vi.fn();
+const mockUseReserved = vi.fn();
+const mockGenerate = vi.fn();
+const mockToast = { toast: vi.fn() };
+
+vi.mock("@/lib/hooks/use-btc-receive", () => ({
+  useBtcReceiveAddress: (...args: unknown[]) => mockUseReceive(...args),
+  useBtcReservedAddresses: (...args: unknown[]) => mockUseReserved(...args),
+}));
+
+vi.mock("../../../../../../../../components/ui/toast", () => ({
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <div data-testid="toast-provider">{children}</div>,
+  useToast: () => mockToast,
+}));
+
+vi.mock("react-qr-code", () => ({
+  __esModule: true,
+  default: ({ value }: { value: string }) => <div data-testid="qr-code" data-value={value} />,
+}));
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(<ToastProvider>{ui}</ToastProvider>);
+}
+
+describe("ReceiveClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseReceive.mockReturnValue({
+      data: {
+        address: "tb1qexampleaddress0000000001",
+        paymentLink: "bitcoin:tb1qexampleaddress0000000001",
+      },
+      isPending: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+      generate: mockGenerate,
+      isGenerating: false,
+    });
+
+    mockUseReserved.mockReturnValue({
+      data: { items: [] },
+      isPending: false,
+      error: null,
+      refetch: vi.fn(),
+      isFetching: false,
+    });
+  });
+
+  it("renders receive header and QR placeholder", () => {
+    renderWithProviders(<ReceiveClient storeId="store-123" hasWallet={true} />);
+
+    expect(screen.getByText(/Receive BTC/i)).toBeInTheDocument();
+    expect(screen.getByTestId("qr-code")).toBeInTheDocument();
+    expect(screen.getByText("tb1qexampleaddress0000000001")).toBeInTheDocument();
+  });
+
+  it("switches to payment link view", () => {
+    renderWithProviders(<ReceiveClient storeId="store-123" hasWallet={true} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Link/i }));
+
+    expect(screen.getByText(/PAYMENT LINK/i)).toBeInTheDocument();
+    expect(screen.getByText("bitcoin:tb1qexampleaddress0000000001")).toBeInTheDocument();
+  });
+
+  it("calls generate when clicking the button", async () => {
+    renderWithProviders(<ReceiveClient storeId="store-123" hasWallet={true} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Generate another address/i }));
+
+    expect(mockGenerate).toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/wallets/btc/receive/receive-client.tsx
+++ b/apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/wallets/btc/receive/receive-client.tsx
@@ -1,0 +1,371 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import QRCode from "react-qr-code";
+import { ArrowLeft, Copy, List, Loader2, QrCode, RefreshCw } from "lucide-react";
+
+import { Button } from "../../../../../../../../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../../../../../../../../components/ui/card";
+import { Select } from "../../../../../../../../components/ui/select";
+import { Skeleton } from "../../../../../../../../components/ui/skeleton";
+import { useToast } from "../../../../../../../../components/ui/toast";
+import { cn } from "../../../../../../../../lib/utils";
+import { useBtcReceiveAddress, useBtcReservedAddresses } from "@/lib/hooks/use-btc-receive";
+import type { WalletReservedAddress } from "@/src/types/wallets";
+
+type ReceiveClientProps = {
+  storeId: string;
+  hasWallet: boolean;
+};
+
+type ReceiveMode = "address" | "link";
+type ViewMode = "current" | "reserved";
+
+function useErrorStatus(error: unknown): number | null {
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+  const record = error as { status?: unknown };
+  const status = record.status;
+  if (typeof status === "number" && Number.isFinite(status)) {
+    return status;
+  }
+  return null;
+}
+
+function formatDate(value?: string): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat("en-US", { dateStyle: "medium", timeStyle: "short" }).format(date);
+}
+
+export function ReceiveClient({ storeId, hasWallet }: ReceiveClientProps) {
+  const { toast } = useToast();
+  const [mode, setMode] = useState<ReceiveMode>("address");
+  const [view, setView] = useState<ViewMode>("current");
+
+  const receiveQuery = useBtcReceiveAddress(storeId);
+  const reservedQuery = useBtcReservedAddresses(storeId, { take: 25, skip: 0, enabled: view === "reserved" });
+
+  const receiveErrorStatus = useErrorStatus(receiveQuery.error);
+  const reservedErrorStatus = useErrorStatus(reservedQuery.error);
+
+  const displayValue = useMemo(() => {
+    if (!receiveQuery.data) return null;
+    return mode === "link" ? receiveQuery.data.paymentLink : receiveQuery.data.address;
+  }, [mode, receiveQuery.data]);
+
+  const loadingReceive = receiveQuery.isPending;
+  const hasReceiveError = !!receiveQuery.error && !loadingReceive;
+  const noWallet = !hasWallet || receiveErrorStatus === 404;
+
+  const handleCopy = async (value: string | null) => {
+    if (!value) return;
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(value);
+        toast({ title: "Copied", description: "Value copied to clipboard" });
+      }
+    } catch (error) {
+      console.warn("Failed to copy value", error);
+      toast({
+        title: "Copy failed",
+        description: "Unable to write to clipboard. Please copy manually.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleGenerate = async () => {
+    try {
+      await receiveQuery.generate();
+      setMode("address");
+      toast({ title: "New address", description: "A new receive address was generated." });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to generate a new address.";
+      toast({ title: "Unable to generate", description: message, variant: "destructive" });
+    }
+  };
+
+  const renderNoWallet = () => (
+    <Card>
+      <CardHeader>
+        <CardTitle>No on-chain BTC wallet configured</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm text-muted-foreground">
+        <p>
+          We could not find an on-chain Bitcoin wallet for this store. Configure a watch-only wallet to start
+          receiving payments.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Button asChild>
+            <Link href={`/stores/${storeId}/wallets/btc/wizard`}>Open wallet wizard</Link>
+          </Button>
+          <Button variant="outline" asChild>
+            <Link href={`/stores/${storeId}/wallets/btc/settings`}>Go to wallet settings</Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+
+  const renderReceiveContent = () => {
+    if (loadingReceive) {
+      return (
+        <Card>
+          <CardHeader>
+            <CardTitle>Receive BTC</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="flex justify-center">
+              <div className="rounded-lg bg-white p-6 shadow-sm dark:bg-white">
+                <Skeleton className="h-56 w-56" />
+              </div>
+            </div>
+            <div className="space-y-3 text-center">
+              <Skeleton className="mx-auto h-4 w-32" />
+              <Skeleton className="mx-auto h-5 w-64" />
+            </div>
+            <div className="flex justify-center gap-2">
+              <Skeleton className="h-10 w-28" />
+              <Skeleton className="h-10 w-28" />
+            </div>
+            <div>
+              <Skeleton className="h-10 w-full sm:w-64" />
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Skeleton className="h-10 w-52" />
+              <Skeleton className="h-10 w-40" />
+            </div>
+          </CardContent>
+        </Card>
+      );
+    }
+
+    if (hasReceiveError) {
+      return (
+        <Card>
+          <CardHeader>
+            <CardTitle>Receive BTC</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <p>
+              {receiveErrorStatus === 401 || receiveErrorStatus === 403
+                ? "You do not have access to this store."
+                : "Unable to load your receive address. Please try again."}
+            </p>
+            <Button onClick={() => receiveQuery.refetch()} disabled={receiveQuery.isFetching}>
+              {receiveQuery.isFetching ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              Retry
+            </Button>
+          </CardContent>
+        </Card>
+      );
+    }
+
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Receive BTC</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="flex justify-center">
+            {displayValue ? (
+              <div className="rounded-lg bg-white p-4 shadow-sm dark:bg-white">
+                <QRCode value={displayValue} size={224} fgColor="#0f172a" />
+              </div>
+            ) : (
+              <div className="flex h-56 w-56 items-center justify-center rounded-lg border border-dashed">
+                <QrCode className="h-10 w-10 text-muted-foreground" />
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-2 text-center">
+            <div className="text-xs font-semibold tracking-[0.2em] text-muted-foreground">
+              {mode === "address" ? "ADDRESS" : "PAYMENT LINK"}
+            </div>
+            <div className="flex items-center justify-center gap-2 break-all font-mono text-sm">
+              <span className="max-w-xl truncate" title={displayValue ?? undefined}>
+                {displayValue ?? "—"}
+              </span>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => handleCopy(displayValue)}
+                disabled={!displayValue}
+                aria-label="Copy"
+              >
+                <Copy className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          <div className="flex justify-center gap-2">
+            <Button
+              variant={mode === "address" ? "default" : "outline"}
+              onClick={() => setMode("address")}
+              size="sm"
+            >
+              Address
+            </Button>
+            <Button variant={mode === "link" ? "default" : "outline"} onClick={() => setMode("link")} size="sm">
+              Link
+            </Button>
+          </div>
+
+          <div className="space-y-2">
+            <div className="text-xs font-semibold tracking-[0.2em] text-muted-foreground">LABELS</div>
+            <Select disabled className="w-full sm:w-64" defaultValue="" aria-label="Labels">
+              <option value="" disabled>
+                Select
+              </option>
+            </Select>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            <Button onClick={handleGenerate} disabled={receiveQuery.isGenerating}>
+              {receiveQuery.isGenerating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+              Generate another address
+            </Button>
+            <Button variant="outline" onClick={() => setView("reserved")}>
+              <List className="mr-2 h-4 w-4" />
+              Reserved addresses
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  };
+
+  const renderReservedContent = () => {
+    if (reservedQuery.isPending) {
+      return (
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle>Reserved Addresses</CardTitle>
+            <Button variant="ghost" size="sm" onClick={() => setView("current")}>
+              <ArrowLeft className="mr-2 h-4 w-4" /> Back
+            </Button>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </CardContent>
+        </Card>
+      );
+    }
+
+    if (reservedQuery.error) {
+      return (
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle>Reserved Addresses</CardTitle>
+            <Button variant="ghost" size="sm" onClick={() => setView("current")}>
+              <ArrowLeft className="mr-2 h-4 w-4" /> Back
+            </Button>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <p>
+              {reservedErrorStatus === 401 || reservedErrorStatus === 403
+                ? "You do not have access to this store."
+                : "Unable to load reserved addresses."}
+            </p>
+            <Button onClick={() => reservedQuery.refetch()} disabled={reservedQuery.isFetching}>
+              {reservedQuery.isFetching ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              Retry
+            </Button>
+          </CardContent>
+        </Card>
+      );
+    }
+
+    const items = reservedQuery.data?.items ?? [];
+
+    return (
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle>Reserved Addresses</CardTitle>
+            <p className="text-sm text-muted-foreground">Addresses reserved in BTCPay Server for your store.</p>
+          </div>
+          <Button variant="ghost" size="sm" onClick={() => setView("current")}>
+            <ArrowLeft className="mr-2 h-4 w-4" /> Back to receive
+          </Button>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {items.length === 0 ? (
+            <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+              No reserved addresses yet.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="py-2 pr-4 font-semibold">Address</th>
+                    <th className="py-2 pr-4 font-semibold">Label</th>
+                    <th className="py-2 pr-4 font-semibold">Reserved At</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((item) => (
+                    <ReservedRow key={item.address} address={item} onCopy={handleCopy} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    );
+  };
+
+  if (view === "reserved") {
+    return renderReservedContent();
+  }
+
+  if (noWallet) {
+    return renderNoWallet();
+  }
+
+  return renderReceiveContent();
+}
+
+type ReservedRowProps = {
+  address: WalletReservedAddress;
+  onCopy: (value: string) => void;
+};
+
+function ReservedRow({ address, onCopy }: ReservedRowProps) {
+  return (
+    <tr className="border-b last:border-0">
+      <td className="py-3 pr-4 font-mono text-xs">
+        <div className="flex items-center gap-2">
+          <span className="truncate" title={address.address}>
+            {address.address}
+          </span>
+          <button
+            type="button"
+            className={cn(
+              "inline-flex h-8 w-8 items-center justify-center rounded-md border text-muted-foreground transition hover:bg-muted",
+            )}
+            aria-label="Copy address"
+            onClick={() => onCopy(address.address)}
+          >
+            <Copy className="h-4 w-4" />
+          </button>
+        </div>
+      </td>
+      <td className="py-3 pr-4 text-sm text-foreground">{address.label ?? "—"}</td>
+      <td className="py-3 pr-4 text-sm text-foreground">{formatDate(address.reservedAt)}</td>
+    </tr>
+  );
+}

--- a/apps/frontend/lib/hooks/use-btc-receive.ts
+++ b/apps/frontend/lib/hooks/use-btc-receive.ts
@@ -1,0 +1,219 @@
+import { useCallback } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { bffFetch } from "@/lib/bff-fetch";
+import type {
+  WalletReceiveAddress,
+  WalletReservedAddressesResponse,
+  WalletReservedAddress,
+} from "@/src/types/wallets";
+
+const RECEIVE_QUERY_KEY = (storeId: string) => ["btc-receive-address", storeId];
+const RESERVED_QUERY_KEY = (storeId: string, take: number, skip: number) => [
+  "btc-reserved-addresses",
+  storeId,
+  take,
+  skip,
+];
+
+async function attemptSessionRefresh(): Promise<boolean> {
+  try {
+    const response = await bffFetch("/api/auth/refresh", { method: "POST" });
+    return response.ok || response.status === 204;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  try {
+    return await response.clone().json();
+  } catch {
+    try {
+      const text = await response.clone().text();
+      return text ? JSON.parse(text) : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+async function fetchWithRefresh(path: string): Promise<Response> {
+  let response = await bffFetch(path);
+  if (response.status === 401) {
+    const refreshed = await attemptSessionRefresh();
+    if (!refreshed) {
+      return response;
+    }
+    response = await bffFetch(path);
+  }
+  return response;
+}
+
+function extractErrorMessage(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+  const message = record.message;
+  if (typeof message === "string" && message.trim()) {
+    return message.trim();
+  }
+  return null;
+}
+
+function normalizeReceiveAddress(payload: unknown): WalletReceiveAddress {
+  if (!payload || typeof payload !== "object") {
+    throw Object.assign(new Error("Invalid receive address payload"), { status: 500 });
+  }
+  const record = payload as Record<string, unknown>;
+  const address = typeof record.address === "string" ? record.address.trim() : "";
+  const paymentLink = typeof record.paymentLink === "string" ? record.paymentLink.trim() : null;
+  const reservedAt = typeof record.reservedAt === "string" ? record.reservedAt.trim() : undefined;
+  const isPayjoinEnabled =
+    typeof record.isPayjoinEnabled === "boolean"
+      ? record.isPayjoinEnabled
+      : typeof record.payjoinEnabled === "boolean"
+        ? record.payjoinEnabled
+        : undefined;
+
+  if (!address) {
+    throw Object.assign(new Error("Receive address is missing"), { status: 500 });
+  }
+
+  const link = paymentLink && paymentLink.toLowerCase().startsWith("bitcoin:") ? paymentLink : `bitcoin:${address}`;
+
+  return { address, paymentLink: link, reservedAt, isPayjoinEnabled } satisfies WalletReceiveAddress;
+}
+
+function normalizeReservedAddresses(payload: unknown): WalletReservedAddressesResponse {
+  if (!payload) {
+    return { items: [] } satisfies WalletReservedAddressesResponse;
+  }
+
+  if (Array.isArray(payload)) {
+    const items = payload
+      .map((item) => normalizeReservedAddress(item))
+      .filter((item): item is WalletReservedAddress => item !== null);
+    return { items, total: payload.length } satisfies WalletReservedAddressesResponse;
+  }
+
+  if (typeof payload === "object") {
+    const record = payload as Record<string, unknown>;
+    const itemsSource = Array.isArray(record.items)
+      ? record.items
+      : Array.isArray(record.data)
+        ? record.data
+        : [];
+    const items = itemsSource
+      .map((item) => normalizeReservedAddress(item))
+      .filter((item): item is WalletReservedAddress => item !== null);
+    const totalValue = record.total;
+    const total = typeof totalValue === "number" && Number.isFinite(totalValue) ? totalValue : undefined;
+    return { items, total } satisfies WalletReservedAddressesResponse;
+  }
+
+  return { items: [] } satisfies WalletReservedAddressesResponse;
+}
+
+function normalizeReservedAddress(payload: unknown): WalletReservedAddress | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const record = payload as Record<string, unknown>;
+  const data = record.data && typeof record.data === "object" ? (record.data as Record<string, unknown>) : {};
+  const addressCandidates = [
+    typeof data.address === "string" ? data.address.trim() : null,
+    typeof record.id === "string" ? record.id.trim() : null,
+  ].filter((entry): entry is string => !!entry && entry.trim().length > 0);
+
+  const address = addressCandidates.find((entry) => entry.length > 0);
+  if (!address) {
+    return null;
+  }
+
+  const label = typeof data.label === "string" && data.label.trim() ? data.label.trim() : undefined;
+  const reservedAt = extractTimestamp(data);
+
+  return { address, label, reservedAt } satisfies WalletReservedAddress;
+}
+
+function extractTimestamp(record: Record<string, unknown>): string | undefined {
+  const candidates = [record.reservedAt, record.createdAt, record.creationTime, record.timestamp, record.date];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  return undefined;
+}
+
+async function fetchReceiveAddress(storeId: string, forceGenerate?: boolean): Promise<WalletReceiveAddress> {
+  const search = new URLSearchParams();
+  if (forceGenerate) {
+    search.set("forceGenerate", "true");
+  }
+  const path = `/api/stores/${storeId}/wallets/btc/actions/receive/next${search.toString() ? `?${search.toString()}` : ""}`;
+  const response = await fetchWithRefresh(path);
+  const payload = await readJson(response);
+  if (!response.ok) {
+    const message = extractErrorMessage(payload) ?? response.statusText ?? "Failed to load receive address";
+    throw Object.assign(new Error(message), { status: response.status });
+  }
+  return normalizeReceiveAddress(payload);
+}
+
+async function fetchReservedAddresses(
+  storeId: string,
+  take: number,
+  skip: number,
+): Promise<WalletReservedAddressesResponse> {
+  const search = new URLSearchParams();
+  if (take > 0) {
+    search.set("take", String(take));
+  }
+  if (skip > 0) {
+    search.set("skip", String(skip));
+  }
+  const path = `/api/stores/${storeId}/wallets/btc/actions/receive/reserved${search.toString() ? `?${search.toString()}` : ""}`;
+  const response = await fetchWithRefresh(path);
+  const payload = await readJson(response);
+  if (!response.ok) {
+    const message = extractErrorMessage(payload) ?? response.statusText ?? "Failed to load reserved addresses";
+    throw Object.assign(new Error(message), { status: response.status });
+  }
+  return normalizeReservedAddresses(payload);
+}
+
+export function useBtcReceiveAddress(storeId: string) {
+  const queryClient = useQueryClient();
+  const query = useQuery({
+    queryKey: RECEIVE_QUERY_KEY(storeId),
+    queryFn: () => fetchReceiveAddress(storeId),
+    enabled: !!storeId,
+  });
+
+  const generateAnother = useMutation({
+    mutationFn: () => fetchReceiveAddress(storeId, true),
+    onSuccess: (data) => {
+      queryClient.setQueryData(RECEIVE_QUERY_KEY(storeId), data);
+    },
+  });
+
+  const generate = useCallback(() => generateAnother.mutateAsync(), [generateAnother]);
+
+  return {
+    ...query,
+    generate,
+    isGenerating: generateAnother.isPending,
+  };
+}
+
+export function useBtcReservedAddresses(storeId: string, { take = 25, skip = 0, enabled = true } = {}) {
+  return useQuery({
+    queryKey: RESERVED_QUERY_KEY(storeId, take, skip),
+    queryFn: () => fetchReservedAddresses(storeId, take, skip),
+    enabled: !!storeId && enabled,
+  });
+}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -27,6 +27,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-qr-code": "^2.0.18",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.8"

--- a/apps/frontend/src/types/wallets.ts
+++ b/apps/frontend/src/types/wallets.ts
@@ -26,3 +26,21 @@ export interface WalletOverview {
   unconfirmedBalance: string;
   label?: string | null;
 }
+
+export interface WalletReceiveAddress {
+  address: string;
+  paymentLink: string;
+  reservedAt?: string;
+  isPayjoinEnabled?: boolean;
+}
+
+export interface WalletReservedAddress {
+  address: string;
+  label?: string;
+  reservedAt?: string;
+}
+
+export interface WalletReservedAddressesResponse {
+  items: WalletReservedAddress[];
+  total?: number;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       react-dom:
         specifier: ^19.1.1
         version: 19.1.1(react@19.1.1)
+      react-qr-code:
+        specifier: ^2.0.18
+        version: 2.0.18(react@19.1.1)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -4995,6 +4998,9 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  qr.js@0.0.0:
+    resolution: {integrity: sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==}
+
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
@@ -5045,6 +5051,11 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-qr-code@2.0.18:
+    resolution: {integrity: sha512-v1Jqz7urLMhkO6jkgJuBYhnqvXagzceg3qJUWayuCK/c6LTIonpWbwxR1f1APGd4xrW/QcQEovNrAojbUz65Tg==}
+    peerDependencies:
+      react: '*'
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -11480,6 +11491,8 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
+  qr.js@0.0.0: {}
+
   qs@6.13.0:
     dependencies:
       side-channel: 1.1.0
@@ -11531,6 +11544,12 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-qr-code@2.0.18(react@19.1.1):
+    dependencies:
+      prop-types: 15.8.1
+      qr.js: 0.0.0
+      react: 19.1.1
 
   react-refresh@0.17.0: {}
 


### PR DESCRIPTION
## Summary
- add numeric normalization helpers for reserved address pagination to keep the receive wallet service stable
- align the receive page with existing wallet presence redirects and use the shared Select placeholder pattern for labels

## Testing
- pnpm --filter frontend exec vitest run 'app/(dashboard)/(stores)/stores/[storeId]/wallets/btc/receive/receive-client.test.tsx'

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69237275877c832f8218f8af85331caf)