### PR TITLE
Fix receive client test typing

### DIFF
--- a/apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/wallets/btc/receive/receive-client.test.tsx
+++ b/apps/frontend/app/(dashboard)/(stores)/stores/[storeId]/wallets/btc/receive/receive-client.test.tsx
@@ -6,15 +6,10 @@ import { ToastProvider } from "../../../../../../../../components/ui/toast";
 import { ReceiveClient } from "./receive-client";
 import type { useBtcReceiveAddress, useBtcReservedAddresses } from "@/lib/hooks/use-btc-receive";
 
-const mockUseReceive = vi.fn<ReturnType<typeof useBtcReceiveAddress>, Parameters<typeof useBtcReceiveAddress>>();
-const mockUseReserved = vi.fn<
-  ReturnType<typeof useBtcReservedAddresses>,
-  Parameters<typeof useBtcReservedAddresses>
->();
-const mockedUseBtcReceiveAddress: typeof useBtcReceiveAddress = (...args) =>
-  mockUseReceive(...args) as ReturnType<typeof useBtcReceiveAddress>;
-const mockedUseBtcReservedAddresses: typeof useBtcReservedAddresses = (...args) =>
-  mockUseReserved(...args) as ReturnType<typeof useBtcReservedAddresses>;
+const mockUseReceive = vi.fn<typeof useBtcReceiveAddress>();
+const mockUseReserved = vi.fn<typeof useBtcReservedAddresses>();
+const mockedUseBtcReceiveAddress: typeof useBtcReceiveAddress = (...args) => mockUseReceive(...args);
+const mockedUseBtcReservedAddresses: typeof useBtcReservedAddresses = (...args) => mockUseReserved(...args);
 const mockGenerate = vi.fn();
 const mockToast = { toast: vi.fn() };
 
@@ -52,7 +47,7 @@ describe("ReceiveClient", () => {
       isFetching: false,
       generate: mockGenerate,
       isGenerating: false,
-    });
+    } as unknown as ReturnType<typeof useBtcReceiveAddress>);
 
     mockUseReserved.mockReturnValue({
       data: { items: [] },
@@ -60,7 +55,7 @@ describe("ReceiveClient", () => {
       error: null,
       refetch: vi.fn(),
       isFetching: false,
-    });
+    } as unknown as ReturnType<typeof useBtcReservedAddresses>);
   });
 
   it("renders receive header and QR placeholder", () => {

--- a/apps/frontend/types/react-qr-code.d.ts
+++ b/apps/frontend/types/react-qr-code.d.ts
@@ -1,0 +1,16 @@
+declare module "react-qr-code" {
+  import type { FunctionComponent, SVGProps } from "react";
+
+  interface QRCodeProps extends SVGProps<SVGSVGElement> {
+    value: string;
+    size?: number;
+    bgColor?: string;
+    fgColor?: string;
+    level?: "L" | "M" | "Q" | "H";
+    includeMargin?: boolean;
+  }
+
+  const QRCode: FunctionComponent<QRCodeProps>;
+
+  export default QRCode;
+}


### PR DESCRIPTION
## Summary
- adjust BTC receive client test mocks to use proper hook typing
- add a local react-qr-code module declaration to satisfy TypeScript

## Testing
- pnpm typecheck


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69238318ba84832f9ac75d3609558292)